### PR TITLE
Add Snowflake PIVOT support with OrderBy functionality

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/snowflakeExtension.pure
@@ -416,18 +416,41 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::snowf
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::processSelectSQLQueryForSnowflake(s:SelectSQLQuery[1], dbConfig : DbConfig[1], format:Format[1], config:Config[1], isSubSelect : Boolean[1], extensions:Extension[*]):String[1]
 {
-  assertEmpty($s.pivot, 'pivot is not supported');
   let opStr = if($s.filteringOperation->isEmpty(), |'', |$s.filteringOperation->map(s|$s->processOperation($dbConfig, $format->indent(), ^$config(callingFromFilter = true), $extensions))->filter(s|$s != '')->joinStrings(' <||> '));
   let havingStr = if($s.havingOperation->isEmpty(), |'', |$s.havingOperation->map(s|$s->processOperation($dbConfig, $format->indent(), $config, $extensions))->filter(s|$s != '')->joinStrings(' <||> '));
 
   $format.separator + 'select ' + if($s.distinct == true,|'distinct ',|'') +
   processSelectColumns($s.columns, $dbConfig, $format->indent(), true, $extensions) +
-  if($s.data == [],|'',| ' ' + $format.separator + 'from ' + $s.data->toOne()->processJoinTreeNode([], $dbConfig, $format->indent(), [], $extensions)) +
+  if($s.data == [],|'',| ' ' + $format.separator + 'from ' + if($s.pivot->isEmpty(),
+                                  | $s.data->toOne()->processJoinTreeNode([], $dbConfig, $format->indent(), [], $extensions),
+                                  | '(' + $s->processPivotForSnowflake($s.pivot->toOne(), $dbConfig, $format, $config, $extensions) + ')'
+                                )) +
   if (eq($opStr, ''), |'', | ' ' + $format.separator + 'where ' + $opStr) +
   if ($s.groupBy->isEmpty(),|'',| ' ' + $format.separator + 'group by '+$s.groupBy->processGroupByColumns($dbConfig, $format->indent(), true, $extensions)->makeString(','))+
   if (eq($havingStr, ''), |'', | ' ' + $format.separator + 'having ' + $havingStr) +
   if ($s.orderBy->isEmpty(),|'',| ' ' + $format.separator + 'order by '+ $s.orderBy->processOrderBy($dbConfig, $format->indent(), $config, $extensions)->makeString(','))+
   + processLimit($s, $dbConfig, $format, $extensions, processTakeDefault_SelectSQLQuery_1__Format_1__DbConfig_1__Extension_MANY__String_1_, processSliceOrDropForSnowflake_SelectSQLQuery_1__Format_1__DbConfig_1__Extension_MANY__Any_1__String_1_);
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::processPivotForSnowflake(s:SelectSQLQuery[1], p:Pivot[1], dbConfig : DbConfig[1], format:Format[1], config:Config[1], extensions:Extension[*]):String[1]
+{
+  let baseQuery = $s.data->toOne()->processJoinTreeNode([], $dbConfig, $format->indent(), [], $extensions);
+  
+  // Process the pivot columns (these will be used in the FOR clause)
+  let pivotColumns = processSelectColumns($p.pivotColumns, $dbConfig, $format->indent(), $config, ' || \'' + pivotColumnDelimeter() + '\' || ', false, $extensions);
+  
+  // Process the aggregation columns (these will be used in the aggregate function)
+  let aggColumns = $p.aggColumns->cast(@Alias);
+  
+  // Build the PIVOT clause with dynamic pivoting using ANY
+  $format.separator + 'select * from ' + $baseQuery + 
+  $format.separator + 'pivot(' + 
+  $aggColumns->map(col | 
+    let colName = $col.name->substring(1);
+    'max(' + $col.relationalElement->processOperation($dbConfig, $format->indent(), $config, $extensions) + ') as "' + $colName + '"'
+  )->joinStrings(', ') + 
+  ' for ' + $pivotColumns + ' in (ANY)' +
+  ')';
 }
 
 function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::processJoinTreeNodeWithLateralJoinForSnowflake(j:JoinTreeNode[1], dbConfig : DbConfig[1], format:Format[1], extensions:Extension[*]):String[1]

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/test/resources/core_relational_snowflake/relational/tests/testSnowflakeRelation.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/test/resources/core_relational_snowflake/relational/tests/testSnowflakeRelation.pure
@@ -87,3 +87,112 @@ function <<test.Test>> meta::relational::tests::pivot::testPivotMultipleAggregat
    let result = meta::relational::functions::sqlQueryToString::toSQLString($query, DatabaseType.Snowflake, meta::relational::runtime::DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
    assertEquals($expected, $result);
 }
+
+function <<test.Test>> meta::relational::tests::pivot::testPivotWithOrderBySnowflake():Boolean[1]
+{
+   let query = {|
+      #TDS
+         city, country, year, treePlanted
+         NYC, USA, 2011, 5000
+         NYC, USA, 2000, 5000
+         SAN, USA, 2000, 2000
+         SAN, USA, 2011, 100
+         LDN, UK, 2011, 3000
+         SAN, USA, 2011, 2500
+         NYC, USA, 2000, 10000
+         NYC, USA, 2012, 7600
+         NYC, USA, 2012, 7600
+      #->pivot(~[year], ~[newCol : x | $x.treePlanted : y | $y->plus()])
+      #->sort('city', 'asc')
+   };
+
+   let expected = 'select *' +
+                  ' from (select "root".city as "city", "root".country as "country", "root".year as "year", "root".treePlanted as "treePlanted"' +
+                  ' from (select \'NYC\' as "city", \'USA\' as "country", 2011 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2000 as "year", 2000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 100 as "treePlanted"' +
+                  ' union all select \'LDN\' as "city", \'UK\' as "country", 2011 as "year", 3000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 2500 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 10000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted") as "root")' +
+                  ' pivot(max("treePlanted") as "newCol" for "year" in (ANY))' +
+                  ' order by "city" asc';
+
+   let result = meta::relational::functions::sqlQueryToString::toSQLString($query, DatabaseType.Snowflake, meta::relational::runtime::DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+   assertEquals($expected, $result);
+}
+
+function <<test.Test>> meta::relational::tests::pivot::testPivotWithMultipleOrderBySnowflake():Boolean[1]
+{
+   let query = {|
+      #TDS
+         city, country, year, treePlanted
+         NYC, USA, 2011, 5000
+         NYC, USA, 2000, 5000
+         SAN, USA, 2000, 2000
+         SAN, USA, 2011, 100
+         LDN, UK, 2011, 3000
+         SAN, USA, 2011, 2500
+         NYC, USA, 2000, 10000
+         NYC, USA, 2012, 7600
+         NYC, USA, 2012, 7600
+      #->pivot(~[year], ~[newCol : x | $x.treePlanted : y | $y->plus()])
+      #->sort('city', 'asc')
+      #->sort('country', 'desc')
+   };
+
+   let expected = 'select *' +
+                  ' from (select "root".city as "city", "root".country as "country", "root".year as "year", "root".treePlanted as "treePlanted"' +
+                  ' from (select \'NYC\' as "city", \'USA\' as "country", 2011 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2000 as "year", 2000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 100 as "treePlanted"' +
+                  ' union all select \'LDN\' as "city", \'UK\' as "country", 2011 as "year", 3000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 2500 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 10000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted") as "root")' +
+                  ' pivot(max("treePlanted") as "newCol" for "year" in (ANY))' +
+                  ' order by "city" asc, "country" desc';
+
+   let result = meta::relational::functions::sqlQueryToString::toSQLString($query, DatabaseType.Snowflake, meta::relational::runtime::DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+   assertEquals($expected, $result);
+}
+
+function <<test.Test>> meta::relational::tests::pivot::testPivotMultipleAggregationsWithOrderBySnowflake():Boolean[1]
+{
+   let query = {|
+      #TDS
+         city, country, year, treePlanted
+         NYC, USA, 2011, 5000
+         NYC, USA, 2000, 5000
+         SAN, USA, 2000, 2000
+         SAN, USA, 2011, 100
+         LDN, UK, 2011, 3000
+         SAN, USA, 2011, 2500
+         NYC, USA, 2000, 10000
+         NYC, USA, 2012, 7600
+         NYC, USA, 2012, 7600
+      #->pivot(~[year], ~[sum : x | $x.treePlanted : y | $y->plus(), count : x | 1 : y | $y->plus()])
+      #->sort('country', 'desc')
+   };
+
+   let expected = 'select *' +
+                  ' from (select "root".city as "city", "root".country as "country", "root".year as "year", "root".treePlanted as "treePlanted"' +
+                  ' from (select \'NYC\' as "city", \'USA\' as "country", 2011 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2000 as "year", 2000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 100 as "treePlanted"' +
+                  ' union all select \'LDN\' as "city", \'UK\' as "country", 2011 as "year", 3000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 2500 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 10000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted") as "root")' +
+                  ' pivot(max("treePlanted") as "sum", count(*) as "count" for "year" in (ANY))' +
+                  ' order by "country" desc';
+
+   let result = meta::relational::functions::sqlQueryToString::toSQLString($query, DatabaseType.Snowflake, meta::relational::runtime::DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+   assertEquals($expected, $result);
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/test/resources/core_relational_snowflake/relational/tests/testSnowflakeRelation.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/test/resources/core_relational_snowflake/relational/tests/testSnowflakeRelation.pure
@@ -1,0 +1,89 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::functions::sqlQueryToString::*;
+import meta::relational::functions::sqlQueryToString::snowflake::*;
+import meta::relational::metamodel::operation::*;
+import meta::relational::metamodel::relation::*;
+import meta::relational::metamodel::*;
+import meta::relational::runtime::*;
+import meta::pure::test::*;
+
+function <<test.Test>> meta::relational::tests::pivot::testPivotSnowflake():Boolean[1]
+{
+   let query = {|
+      #TDS
+         city, country, year, treePlanted
+         NYC, USA, 2011, 5000
+         NYC, USA, 2000, 5000
+         SAN, USA, 2000, 2000
+         SAN, USA, 2011, 100
+         LDN, UK, 2011, 3000
+         SAN, USA, 2011, 2500
+         NYC, USA, 2000, 10000
+         NYC, USA, 2012, 7600
+         NYC, USA, 2012, 7600
+      #->pivot(~[year], ~[newCol : x | $x.treePlanted : y | $y->plus()])
+   };
+
+   let expected = 'select *' +
+                  ' from (select "root".city as "city", "root".country as "country", "root".year as "year", "root".treePlanted as "treePlanted"' +
+                  ' from (select \'NYC\' as "city", \'USA\' as "country", 2011 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2000 as "year", 2000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 100 as "treePlanted"' +
+                  ' union all select \'LDN\' as "city", \'UK\' as "country", 2011 as "year", 3000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 2500 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 10000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted") as "root")' +
+                  ' pivot(max("treePlanted") as "newCol" for "year" in (ANY))';
+
+   let result = meta::relational::functions::sqlQueryToString::toSQLString($query, DatabaseType.Snowflake, meta::relational::runtime::DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+   assertEquals($expected, $result);
+}
+
+function <<test.Test>> meta::relational::tests::pivot::testPivotMultipleAggregationsSnowflake():Boolean[1]
+{
+   let query = {|
+      #TDS
+         city, country, year, treePlanted
+         NYC, USA, 2011, 5000
+         NYC, USA, 2000, 5000
+         SAN, USA, 2000, 2000
+         SAN, USA, 2011, 100
+         LDN, UK, 2011, 3000
+         SAN, USA, 2011, 2500
+         NYC, USA, 2000, 10000
+         NYC, USA, 2012, 7600
+         NYC, USA, 2012, 7600
+      #->pivot(~[year], ~[sum : x | $x.treePlanted : y | $y->plus(), count : x | 1 : y | $y->plus()])
+   };
+
+   let expected = 'select *' +
+                  ' from (select "root".city as "city", "root".country as "country", "root".year as "year", "root".treePlanted as "treePlanted"' +
+                  ' from (select \'NYC\' as "city", \'USA\' as "country", 2011 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 5000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2000 as "year", 2000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 100 as "treePlanted"' +
+                  ' union all select \'LDN\' as "city", \'UK\' as "country", 2011 as "year", 3000 as "treePlanted"' +
+                  ' union all select \'SAN\' as "city", \'USA\' as "country", 2011 as "year", 2500 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2000 as "year", 10000 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted"' +
+                  ' union all select \'NYC\' as "city", \'USA\' as "country", 2012 as "year", 7600 as "treePlanted") as "root")' +
+                  ' pivot(max("treePlanted") as "sum", count(*) as "count" for "year" in (ANY))';
+
+   let result = meta::relational::functions::sqlQueryToString::toSQLString($query, DatabaseType.Snowflake, meta::relational::runtime::DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+   assertEquals($expected, $result);
+}


### PR DESCRIPTION
This PR adds support for the PIVOT function in Snowflake SQL generation with dynamic pivoting using the 'ANY' keyword. It also includes test cases for OrderBy functionality with PIVOT operations.

The implementation includes:
1. A new `processPivotForSnowflake` function to handle dynamic pivoting
2. Modifications to `processSelectSQLQueryForSnowflake` to support PIVOT operations
3. Test cases for basic PIVOT functionality
4. Test cases for PIVOT with multiple aggregations
5. Test cases for PIVOT with OrderBy functionality (single column, multiple columns, and with multiple aggregations)

This PR supersedes PR #3 which only contained the OrderBy test cases.

Link to Devin run: https://app.devin.ai/sessions/ba7b10cecc9d493eabdb7598175190a7
Requested by: Neema.Raphael@gs.com