### PR TITLE
Update DuckDB Time Slice Implementation

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/duckdbExtension.pure
@@ -34,6 +34,7 @@ function <<access.private>> meta::relational::functions::sqlQueryToString::duckD
       commonTableExpressionsProcessor = processCommonTableExpressionsProcessorDefault_CommonTableExpression_MANY__SqlGenerationContext_1__Boolean_1__String_1_,
       columnNameToIdentifier = columnNameToIdentifierForDuckDB_String_1__DbConfig_1__String_1_,
       identifierProcessor = processIdentifierWithDoubleQuotes_String_1__DbConfig_1__String_1_,
+      timeSliceProcessor = duckDBTimeSliceOperation_TimeSliceOperation_1__SqlGenerationContext_1__String_1_,
       dynaFuncDispatch = $dynaFuncDispatch,
       ddlCommandsTranslator = getDDLCommandsTranslator()
    );

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/timeSliceOperation.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-duckdb/legend-engine-xt-relationalStore-duckdb-pure/src/main/resources/core_relational_duckdb/relational/sqlQueryToString/timeSliceOperation.pure
@@ -1,0 +1,35 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::functions::sqlQueryToString::duckdb::*;
+import meta::relational::functions::sqlQueryToString::default::*;
+import meta::relational::functions::sqlQueryToString::*;
+import meta::relational::metamodel::operation::*;
+import meta::relational::metamodel::relation::*;
+import meta::relational::metamodel::*;
+import meta::relational::runtime::*;
+import meta::pure::extension::*;
+import meta::core::runtime::*;
+
+function meta::relational::functions::sqlQueryToString::duckdb::duckDBTimeSliceOperation(timeSliceOp:TimeSliceOperation[1], sgc:SqlGenerationContext[1]): String[1]
+{
+   let interval = $timeSliceOp.interval;
+   let intervalField = $timeSliceOp.intervalField;
+   let intervalUnit = $timeSliceOp.intervalUnit;
+   let columnExpression = $timeSliceOp.columnExpression->meta::relational::functions::sqlQueryToString::default::defaultTimeSliceColumnExpression($sgc);
+   
+   // Use time_bucket function for DuckDB
+   // Reference: https://duckdb.org/docs/stable/sql/functions/date.html#time-bucket
+   'time_bucket(\'' + $interval->toString() + ' ' + $intervalUnit->toString() + '\', ' + $columnExpression + ')';
+}


### PR DESCRIPTION
# Update DuckDB Time Slice Implementation

## Changes
- Updated DuckDB time_bucket function implementation to use the correct syntax
- Modified time slice operation to match DuckDB's native time_bucket function format
- Improved interval specification for precise time slicing

## References
- [DuckDB Time Bucket Documentation](https://duckdb.org/docs/stable/sql/functions/date.html#time-bucket)
- [Link to Devin run](https://app.devin.ai/sessions/688a11013859459981ad26bd162d2dbe)

Requested by: Neema.Raphael@gs.com