### PR TITLE
Add window frame support to window functions

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/frame/frame.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/frame/frame.pure
@@ -1,0 +1,52 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+/**
+ * WindowFrame represents the frame specification for window functions.
+ * It defines the range of rows that are included in the window frame.
+ */
+Class meta::pure::metamodel::relation::WindowFrame
+{
+    mode: String[1]; // ROWS, RANGE, or GROUPS
+    startBound: String[1]; // UNBOUNDED PRECEDING, CURRENT ROW, or N PRECEDING/FOLLOWING
+    endBound: String[1]; // UNBOUNDED FOLLOWING, CURRENT ROW, or N PRECEDING/FOLLOWING
+}
+
+/**
+ * Creates a window frame specification with the given mode and bounds.
+ * @param mode - The frame mode (ROWS, RANGE, or GROUPS)
+ * @param startBound - The start bound of the frame
+ * @param endBound - The end bound of the frame
+ * @return A WindowFrame instance
+ */
+function meta::pure::functions::relation::windowFrame(mode: String[1], startBound: String[1], endBound: String[1]): WindowFrame[1]
+{
+    ^WindowFrame(
+        mode = $mode,
+        startBound = $startBound,
+        endBound = $endBound
+    );
+}
+
+/**
+ * Creates a default window frame with ROWS mode and bounds from UNBOUNDED PRECEDING to CURRENT ROW.
+ * @return A WindowFrame instance with default settings
+ */
+function meta::pure::functions::relation::defaultWindowFrame(): WindowFrame[1]
+{
+    windowFrame('ROWS', 'UNBOUNDED PRECEDING', 'CURRENT ROW');
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/frame/groups.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/frame/groups.pure
@@ -1,0 +1,67 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+/**
+ * Creates a window frame with GROUPS mode.
+ * GROUPS mode defines the window frame in terms of groups of rows that have the same values for the ORDER BY key.
+ * 
+ * @param startBound - The start bound of the frame (e.g., 'UNBOUNDED PRECEDING', 'CURRENT ROW', '1 PRECEDING')
+ * @param endBound - The end bound of the frame (e.g., 'UNBOUNDED FOLLOWING', 'CURRENT ROW', '1 FOLLOWING')
+ * @return A WindowFrame instance with GROUPS mode
+ */
+function meta::pure::functions::relation::groupsFrame(startBound: String[1], endBound: String[1]): WindowFrame[1]
+{
+    windowFrame('GROUPS', $startBound, $endBound);
+}
+
+/**
+ * Creates a window frame with GROUPS mode that includes all groups from the start of the partition to the current row.
+ * @return A WindowFrame instance with GROUPS mode from UNBOUNDED PRECEDING to CURRENT ROW
+ */
+function meta::pure::functions::relation::groupsUnboundedPrecedingToCurrentRow(): WindowFrame[1]
+{
+    groupsFrame('UNBOUNDED PRECEDING', 'CURRENT ROW');
+}
+
+/**
+ * Creates a window frame with GROUPS mode that includes all groups in the partition.
+ * @return A WindowFrame instance with GROUPS mode from UNBOUNDED PRECEDING to UNBOUNDED FOLLOWING
+ */
+function meta::pure::functions::relation::groupsUnboundedPrecedingToUnboundedFollowing(): WindowFrame[1]
+{
+    groupsFrame('UNBOUNDED PRECEDING', 'UNBOUNDED FOLLOWING');
+}
+
+/**
+ * Creates a window frame with GROUPS mode that includes the current group.
+ * @return A WindowFrame instance with GROUPS mode from CURRENT ROW to CURRENT ROW
+ */
+function meta::pure::functions::relation::groupsCurrentRow(): WindowFrame[1]
+{
+    groupsFrame('CURRENT ROW', 'CURRENT ROW');
+}
+
+/**
+ * Creates a window frame with GROUPS mode that includes a specified number of groups before and after the current group.
+ * @param preceding - Number of groups preceding the current group
+ * @param following - Number of groups following the current group
+ * @return A WindowFrame instance with GROUPS mode with the specified bounds
+ */
+function meta::pure::functions::relation::groupsRange(preceding: Integer[1], following: Integer[1]): WindowFrame[1]
+{
+    groupsFrame($preceding->toString() + ' PRECEDING', $following->toString() + ' FOLLOWING');
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/tests/testWindowFrame.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/tests/testWindowFrame.pure
@@ -1,0 +1,122 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::pure::test::pct::*;
+import meta::pure::metamodel::relation::*;
+import meta::pure::functions::relation::*;
+
+function <<PCT.test>> meta::pure::functions::relation::tests::window::testWindowFrameRows<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+                | #TDS
+                  id, grp, name
+                  1, 2, A
+                  2, 1, B
+                  3, 3, C
+                  4, 4, D
+                  5, 2, E
+                  6, 1, F
+                  7, 3, G
+                  8, 1, H
+                  9, 5, I
+                  10, 0, J
+                #->extend(~newCol:{p, w, r| $p->sum($w, $r).id}, over(~grp, ~id->ascending(), windowFrame('ROWS', 'UNBOUNDED PRECEDING', 'CURRENT ROW')))
+               };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   id,grp,name,newCol\n'+
+                  '   1,2,A,1\n'+
+                  '   5,2,E,6\n'+
+                  '   2,1,B,2\n'+
+                  '   6,1,F,8\n'+
+                  '   8,1,H,16\n'+
+                  '   3,3,C,3\n'+
+                  '   7,3,G,10\n'+
+                  '   4,4,D,4\n'+
+                  '   9,5,I,9\n'+
+                  '   10,0,J,10\n'+
+                  '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::window::testWindowFrameRange<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+                | #TDS
+                  id, grp, name
+                  1, 2, A
+                  2, 1, B
+                  3, 3, C
+                  4, 4, D
+                  5, 2, E
+                  6, 1, F
+                  7, 3, G
+                  8, 1, H
+                  9, 5, I
+                  10, 0, J
+                #->extend(~newCol:{p, w, r| $p->sum($w, $r).id}, over(~grp, ~id->ascending(), windowFrame('RANGE', '1 PRECEDING', '1 FOLLOWING')))
+               };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   id,grp,name,newCol\n'+
+                  '   1,2,A,6\n'+
+                  '   5,2,E,6\n'+
+                  '   2,1,B,8\n'+
+                  '   6,1,F,14\n'+
+                  '   8,1,H,8\n'+
+                  '   3,3,C,10\n'+
+                  '   7,3,G,7\n'+
+                  '   4,4,D,4\n'+
+                  '   9,5,I,9\n'+
+                  '   10,0,J,10\n'+
+                  '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
+}
+
+function <<PCT.test>> meta::pure::functions::relation::tests::window::testWindowFrameGroups<T|m>(f:Function<{Function<{->T[m]}>[1]->T[m]}>[1]):Boolean[1]
+{
+    let expr = {
+                | #TDS
+                  id, grp, name
+                  1, 2, A
+                  2, 1, B
+                  3, 3, C
+                  4, 4, D
+                  5, 2, E
+                  6, 1, F
+                  7, 3, G
+                  8, 1, H
+                  9, 5, I
+                  10, 0, J
+                #->extend(~newCol:{p, w, r| $p->sum($w, $r).id}, over(~grp, ~id->ascending(), windowFrame('GROUPS', 'UNBOUNDED PRECEDING', 'UNBOUNDED FOLLOWING')))
+               };
+
+    let res =  $f->eval($expr);
+
+    assertEquals( '#TDS\n'+
+                  '   id,grp,name,newCol\n'+
+                  '   1,2,A,6\n'+
+                  '   5,2,E,6\n'+
+                  '   2,1,B,16\n'+
+                  '   6,1,F,16\n'+
+                  '   8,1,H,16\n'+
+                  '   3,3,C,10\n'+
+                  '   7,3,G,10\n'+
+                  '   4,4,D,4\n'+
+                  '   9,5,I,9\n'+
+                  '   10,0,J,10\n'+
+                  '#', $res->sort([~grp->ascending(), ~id->ascending()])->toString());
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/frameBoundProcessor.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/frameBoundProcessor.pure
@@ -1,0 +1,37 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::functions::sqlQueryToString::default::*;
+import meta::relational::functions::sqlQueryToString::*;
+import meta::relational::metamodel::operation::*;
+import meta::relational::metamodel::relation::*;
+import meta::relational::metamodel::*;
+import meta::relational::runtime::*;
+import meta::pure::extension::*;
+import meta::core::runtime::*;
+import meta::pure::metamodel::relation::*;
+
+function meta::relational::functions::sqlQueryToString::default::processFrameBoundDefault(bound: String[1]): String[1]
+{
+   if($bound == 'CURRENT ROW', 
+      'CURRENT ROW', 
+      if($bound == 'UNBOUNDED PRECEDING', 
+         'UNBOUNDED PRECEDING', 
+         if($bound == 'UNBOUNDED FOLLOWING', 
+            'UNBOUNDED FOLLOWING', 
+            $bound
+         )
+      )
+   );
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/windowFrameProcessor.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/windowFrameProcessor.pure
@@ -1,0 +1,38 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::functions::sqlQueryToString::default::*;
+import meta::relational::functions::sqlQueryToString::*;
+import meta::relational::metamodel::operation::*;
+import meta::relational::metamodel::relation::*;
+import meta::relational::metamodel::*;
+import meta::relational::runtime::*;
+import meta::pure::extension::*;
+import meta::core::runtime::*;
+import meta::pure::metamodel::relation::*;
+
+function meta::relational::functions::sqlQueryToString::default::processWindowFrame(window: WindowColumn[1], sgc: SqlGenerationContext[1]): String[1]
+{
+   if($window.frame->isEmpty(), 
+      '', 
+      ' ' + $window.frame->toOne().mode + ' BETWEEN ' + 
+      processFrameBound($window.frame->toOne().startBound) + ' AND ' + 
+      processFrameBound($window.frame->toOne().endBound)
+   );
+}
+
+function meta::relational::functions::sqlQueryToString::default::processFrameBound(bound: String[1]): String[1]
+{
+   $bound;
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/windowProcessor.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-generation/legend-engine-xt-relationalStore-pure/legend-engine-xt-relationalStore-sqlDialectTranslation-pure/src/main/resources/core_external_store_relational_sql_dialect_translation/defaults/windowProcessor.pure
@@ -1,0 +1,40 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::functions::sqlQueryToString::default::*;
+import meta::relational::functions::sqlQueryToString::*;
+import meta::relational::metamodel::operation::*;
+import meta::relational::metamodel::relation::*;
+import meta::relational::metamodel::*;
+import meta::relational::runtime::*;
+import meta::pure::extension::*;
+import meta::core::runtime::*;
+import meta::pure::metamodel::relation::*;
+
+function meta::relational::functions::sqlQueryToString::default::processWindowColumnDefault(window: WindowColumn[1], sgc: SqlGenerationContext[1]): String[1]
+{
+   let partitionBy = if($window.partitionBy->isEmpty(), 
+                        '', 
+                        'partition by ' + $window.partitionBy->map(p | $p->processOperation($sgc))->joinStrings(', '));
+   
+   let orderBy = if($window.orderBy->isEmpty(), 
+                    '', 
+                    'order by ' + $window.orderBy->map(o | $o.column->processOperation($sgc) + if($o.direction == SortDirection.ASC, ' asc', ' desc'))->joinStrings(', '));
+   
+   let frame = processWindowFrame($window, $sgc);
+   
+   let separator = if($partitionBy == '' || $orderBy == '', '', ' ');
+   
+   $partitionBy + $separator + $orderBy + $frame;
+}


### PR DESCRIPTION
This PR adds support for window frames in window functions, allowing for more complex window operations.

Changes include:
- Added frame.pure and groups.pure for window frame definitions
- Added SQL dialect translation support for window frames
- Added test cases for window frame operations

Link to Devin run: https://app.devin.ai/sessions/688a11013859459981ad26bd162d2dbe
Requested by: Neema.Raphael@gs.com