### PR TITLE
Add window frame clause support to over function

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/over.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-relation/legend-engine-pure-functions-relation-pure/src/main/resources/core_functions_relation/relation/functions/olap/over.pure
@@ -98,3 +98,107 @@ function
 {
   over([],$sortInfo,$frame)
 }
+
+function
+    <<functionType.NormalizeRequiredFunction,
+    PCT.function>>
+    meta::pure::functions::relation::over<T>(cols:String[*], sortInfo:SortInfo<(?:?)⊆T>[*], frameType:String[1], frameStart:Any[1], frameEnd:Any[1]):_Window<T>[1]
+{
+  let frame = if($frameType == 'ROWS',
+                | processRowsFrame($frameStart, $frameEnd),
+                | processRangeFrame($frameStart, $frameEnd)
+              );
+  ^_Window<T>
+  (
+    partition=$cols,
+    sortInfo=$sortInfo,
+    frame=$frame
+  );
+}
+
+function
+    <<access.private>>
+    meta::pure::functions::relation::processRowsFrame(frameStart:Any[1], frameEnd:Any[1]):Rows[1]
+{
+  if($frameStart == 'UNBOUNDED PRECEDING',
+    | if($frameEnd == 'UNBOUNDED FOLLOWING',
+        | rows(unbounded(), unbounded()),
+        | if($frameEnd == 'CURRENT ROW',
+            | rows(unbounded(), 0),
+            | rows(unbounded(), $frameEnd->toInteger())
+          )
+      ),
+    | if($frameStart == 'CURRENT ROW',
+        | if($frameEnd == 'UNBOUNDED FOLLOWING',
+            | rows(0, unbounded()),
+            | if($frameEnd == 'CURRENT ROW',
+                | rows(0, 0),
+                | rows(0, $frameEnd->toInteger())
+              )
+          ),
+        | if($frameEnd == 'UNBOUNDED FOLLOWING',
+            | rows($frameStart->toInteger(), unbounded()),
+            | if($frameEnd == 'CURRENT ROW',
+                | rows($frameStart->toInteger(), 0),
+                | rows($frameStart->toInteger(), $frameEnd->toInteger())
+              )
+          )
+      )
+  );
+}
+
+function
+    <<access.private>>
+    meta::pure::functions::relation::processRangeFrame(frameStart:Any[1], frameEnd:Any[1]):_Range[1]
+{
+  if($frameStart == 'UNBOUNDED PRECEDING',
+    | if($frameEnd == 'UNBOUNDED FOLLOWING',
+        | _range(unbounded(), unbounded()),
+        | if($frameEnd == 'CURRENT ROW',
+            | _range(unbounded(), 0),
+            | _range(unbounded(), $frameEnd->toInteger())
+          )
+      ),
+    | if($frameStart == 'CURRENT ROW',
+        | if($frameEnd == 'UNBOUNDED FOLLOWING',
+            | _range(0, unbounded()),
+            | if($frameEnd == 'CURRENT ROW',
+                | _range(0, 0),
+                | _range(0, $frameEnd->toInteger())
+              )
+          ),
+        | if($frameEnd == 'UNBOUNDED FOLLOWING',
+            | _range($frameStart->toInteger(), unbounded()),
+            | if($frameEnd == 'CURRENT ROW',
+                | _range($frameStart->toInteger(), 0),
+                | _range($frameStart->toInteger(), $frameEnd->toInteger())
+              )
+          )
+      )
+  );
+}
+
+function
+    <<functionType.NormalizeRequiredFunction,
+    PCT.function>>
+    meta::pure::functions::relation::over<T>(cols:String[*], sortInfo:SortInfo<(?:?)⊆T>[*], frameType:String[1]):_Window<T>[1]
+{
+  // Default to RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+  over($cols, $sortInfo, $frameType, 'UNBOUNDED PRECEDING', 'CURRENT ROW');
+}
+
+function
+    <<functionType.NormalizeRequiredFunction,
+    PCT.function>>
+    meta::pure::functions::relation::over<T>(cols:ColSpec<(?:?)⊆T>[1], sortInfo:SortInfo<(?:?)⊆T>[*], frameType:String[1], frameStart:Any[1], frameEnd:Any[1]):_Window<T>[1]
+{
+  over($cols.name, $sortInfo, $frameType, $frameStart, $frameEnd);
+}
+
+function
+    <<functionType.NormalizeRequiredFunction,
+    PCT.function>>
+    meta::pure::functions::relation::over<T>(cols:ColSpecArray<(?:?)⊆T>[1], sortInfo:SortInfo<(?:?)⊆T>[*], frameType:String[1], frameStart:Any[1], frameEnd:Any[1]):_Window<T>[1]
+{
+  over($cols.names, $sortInfo, $frameType, $frameStart, $frameEnd);
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/processWindowColumn.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/sqlQueryToString/processWindowColumn.pure
@@ -1,0 +1,52 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::functions::sqlQueryToString::snowflake::*;
+import meta::relational::metamodel::operation::*;
+import meta::relational::functions::sqlQueryToString::*;
+import meta::pure::metamodel::relation::*;
+
+function meta::relational::functions::sqlQueryToString::snowflake::processWindowColumn(w:WindowColumn[1], sgc:SqlGenerationContext[1]):String[1]
+{
+   let window = $w.window;
+   let partitionBy = if($window.partition->isEmpty(), |'', |'Partition By ' + $window.partition->map(p|$p->processOperation($sgc))->joinStrings(', '));
+   let orderBy = if($window.sortInfo->isEmpty(), |'', |'Order By ' + $window.sortInfo->map(s|$s.column->processOperation($sgc) + ' ' + $s.direction->toString())->joinStrings(', '));
+   
+   // Add frame clause processing
+   let frameClause = if($window.frame->isEmpty(), 
+                       |'', 
+                       |' ' + processWindowFrame($window.frame->toOne()));
+   
+   $w.func->processOperation($sgc) + ' OVER (' + $partitionBy + if($partitionBy->isEmpty() || $orderBy->isEmpty(), |'', |' ') + $orderBy + $frameClause + ')';
+}
+
+function <<access.private>> meta::relational::functions::sqlQueryToString::snowflake::processWindowFrame(frame:Frame[1]):String[1]
+{
+  let frameType = $frame->match([
+    r:Rows[1] | 'ROWS',
+    r:_Range[1] | 'RANGE'
+  ]);
+  
+  let frameStart = $frame.offsetFrom->match([
+    u:UnboundedFrameValue[1] | 'UNBOUNDED PRECEDING',
+    i:FrameIntValue[1] | if($i.value == 0, |'CURRENT ROW', |$i.value->toString() + ' PRECEDING')
+  ]);
+  
+  let frameEnd = $frame.offsetTo->match([
+    u:UnboundedFrameValue[1] | 'UNBOUNDED FOLLOWING',
+    i:FrameIntValue[1] | if($i.value == 0, |'CURRENT ROW', |$i.value->toString() + ' FOLLOWING')
+  ]);
+  
+  $frameType + ' BETWEEN ' + $frameStart + ' AND ' + $frameEnd;
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/tests/testSnowflakeWindowFrame.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-snowflake/legend-engine-xt-relationalStore-snowflake-pure/src/main/resources/core_relational_snowflake/relational/tests/testSnowflakeWindowFrame.pure
@@ -1,0 +1,87 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::relational::functions::sqlstring::*;
+import meta::relational::runtime::*;
+import meta::external::store::relational::runtime::*;
+import meta::relational::tests::*;
+import meta::external::store::relational::tests::*;
+import meta::pure::functions::math::olap::*;
+import meta::relational::tests::model::simple::*;
+import meta::pure::functions::relation::*;
+
+function <<test.Test>> meta::relational::tests::tds::snowflake::testWindowFrameRowsUnboundedPrecedingCurrentRowSnowflake():Boolean[1]
+{
+  let func = {|
+    Person.all()
+      ->project([
+          col(p|$p.lastName, 'lastName'),
+          col(window(p|$p.firstName, sortAsc(p|$p.lastName), 'ROWS', 'UNBOUNDED PRECEDING', 'CURRENT ROW', func(p|$p.age->toOne(), y|$y->average())), 'ageAverageWindow')
+      ])
+  };
+  let result = toSQLString($func, simpleRelationalMappingInc, DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+  assertEquals('select "root".LASTNAME as "lastName", avg(1.0 * "root".AGE) OVER (Partition By "root".FIRSTNAME Order By "root".LASTNAME ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as "ageAverageWindow" from personTable as "root"', $result);
+}
+
+function <<test.Test>> meta::relational::tests::tds::snowflake::testWindowFrameRangeUnboundedPrecedingUnboundedFollowingSnowflake():Boolean[1]
+{
+  let func = {|
+    Person.all()
+      ->project([
+          col(p|$p.lastName, 'lastName'),
+          col(window(p|$p.firstName, sortAsc(p|$p.lastName), 'RANGE', 'UNBOUNDED PRECEDING', 'UNBOUNDED FOLLOWING', func(p|$p.age->toOne(), y|$y->average())), 'ageAverageWindow')
+      ])
+  };
+  let result = toSQLString($func, simpleRelationalMappingInc, DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+  assertEquals('select "root".LASTNAME as "lastName", avg(1.0 * "root".AGE) OVER (Partition By "root".FIRSTNAME Order By "root".LASTNAME ASC RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as "ageAverageWindow" from personTable as "root"', $result);
+}
+
+function <<test.Test>> meta::relational::tests::tds::snowflake::testWindowFrameRowsCurrentRowFollowingSnowflake():Boolean[1]
+{
+  let func = {|
+    Person.all()
+      ->project([
+          col(p|$p.lastName, 'lastName'),
+          col(window(p|$p.firstName, sortAsc(p|$p.lastName), 'ROWS', 'CURRENT ROW', '3', func(p|$p.age->toOne(), y|$y->average())), 'ageAverageWindow')
+      ])
+  };
+  let result = toSQLString($func, simpleRelationalMappingInc, DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+  assertEquals('select "root".LASTNAME as "lastName", avg(1.0 * "root".AGE) OVER (Partition By "root".FIRSTNAME Order By "root".LASTNAME ASC ROWS BETWEEN CURRENT ROW AND 3 FOLLOWING) as "ageAverageWindow" from personTable as "root"', $result);
+}
+
+function <<test.Test>> meta::relational::tests::tds::snowflake::testWindowFrameRangePrecedingCurrentRowSnowflake():Boolean[1]
+{
+  let func = {|
+    Person.all()
+      ->project([
+          col(p|$p.lastName, 'lastName'),
+          col(window(p|$p.firstName, sortAsc(p|$p.lastName), 'RANGE', '2', 'CURRENT ROW', func(p|$p.age->toOne(), y|$y->average())), 'ageAverageWindow')
+      ])
+  };
+  let result = toSQLString($func, simpleRelationalMappingInc, DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+  assertEquals('select "root".LASTNAME as "lastName", avg(1.0 * "root".AGE) OVER (Partition By "root".FIRSTNAME Order By "root".LASTNAME ASC RANGE BETWEEN 2 PRECEDING AND CURRENT ROW) as "ageAverageWindow" from personTable as "root"', $result);
+}
+
+function <<test.Test>> meta::relational::tests::tds::snowflake::testWindowFrameRowsPrecedingFollowingSnowflake():Boolean[1]
+{
+  let func = {|
+    Person.all()
+      ->project([
+          col(p|$p.lastName, 'lastName'),
+          col(window(p|$p.firstName, sortAsc(p|$p.lastName), 'ROWS', '1', '1', func(p|$p.age->toOne(), y|$y->average())), 'ageAverageWindow')
+      ])
+  };
+  let result = toSQLString($func, simpleRelationalMappingInc, DatabaseType.Snowflake, meta::relational::extension::relationalExtensions());
+  assertEquals('select "root".LASTNAME as "lastName", avg(1.0 * "root".AGE) OVER (Partition By "root".FIRSTNAME Order By "root".LASTNAME ASC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) as "ageAverageWindow" from personTable as "root"', $result);
+}


### PR DESCRIPTION
# Add window frame clause support to over function

This PR extends the over function in legend-engine to support window frame clauses, following Snowflakes SQL syntax specification.

Changes include:
- Added new function signatures with frame clause parameters to over.pure
- Added helper functions for frame clause creation
- Updated Snowflake SQL generator to support window frame clauses
- Added Pure tests to verify window frame functionality

Link to Devin run: https://app.devin.ai/sessions/35e74eacfbd1481ba694f3b0d4821505
Requested by: Neema.Raphael@gs.com