### PR TITLE
Add currentUser function

### DIFF
--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/runtime/currentUser.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/runtime/currentUser.pure
@@ -1,0 +1,15 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+native function <<functionType.SideEffectFunction>> meta::core::runtime::currentUser():String[1];

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/runtime/tests/testCurrentUser.pure
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-functions-unclassified-pure/src/main/resources/core_functions_unclassified/runtime/tests/testCurrentUser.pure
@@ -1,0 +1,22 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import meta::core::runtime::*;
+
+function <<test.Test>> meta::core::runtime::tests::testCurrentUser():Boolean[1]
+{
+  let username = currentUser();
+  assert($username->isNotEmpty(), 'Username should not be empty');
+  true;
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsExtensionCompiled.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsExtensionCompiled.java
@@ -45,6 +45,7 @@ import org.finos.legend.pure.runtime.java.extension.functions.compiled.natives.m
 import org.finos.legend.pure.runtime.java.extension.functions.compiled.natives.meta.NewLambdaFunction;
 import org.finos.legend.pure.runtime.java.extension.functions.compiled.natives.meta.NewProperty;
 import org.finos.legend.pure.runtime.java.extension.functions.compiled.natives.meta.NewQualifiedProperty;
+import org.finos.legend.pure.runtime.java.extension.functions.compiled.natives.runtime.CurrentUser;
 import org.finos.legend.pure.runtime.java.extension.functions.compiled.natives.runtime.CurrentUserId;
 import org.finos.legend.pure.runtime.java.extension.functions.compiled.natives.runtime.Guid;
 import org.finos.legend.pure.runtime.java.extension.functions.compiled.natives.runtime.IsOptionSet;
@@ -112,6 +113,7 @@ public class FunctionsExtensionCompiled extends AbstractCompiledExtension
                 new NewQualifiedProperty(),
 
                 //Runtime
+                new CurrentUser(),
                 new CurrentUserId(),
                 new IsOptionSet(),
                 new Guid(),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/natives/runtime/CurrentUser.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/compiled/natives/runtime/CurrentUser.java
@@ -1,0 +1,25 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.extension.functions.compiled.natives.runtime;
+
+import org.finos.legend.pure.runtime.java.compiled.generation.processors.natives.AbstractNativeFunctionGeneric;
+
+public class CurrentUser extends AbstractNativeFunctionGeneric
+{
+    public CurrentUser()
+    {
+        super("FunctionsGen.currentUser", new Class[]{}, "currentUser__String_1_");
+    }
+}

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/resources/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsGen.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-compiled-functions-unclassified/src/main/resources/org/finos/legend/pure/runtime/java/extension/functions/compiled/FunctionsGen.java
@@ -205,4 +205,9 @@ public class FunctionsGen extends org.finos.legend.pure.runtime.java.extension.f
     {
         return traceSpan(es, function, operationName, funcToGetTags, tagsCritical, CoreGen.bridge);
     }
+
+    public static String currentUser()
+    {
+        return System.getProperty("user.name");
+    }
 }

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/FunctionExtensionInterpreted.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/FunctionExtensionInterpreted.java
@@ -41,6 +41,7 @@ import org.finos.legend.pure.runtime.java.extension.functions.interpreted.native
 import org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.meta.NewLambdaFunction;
 import org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.meta.NewProperty;
 import org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.meta.NewQualifiedProperty;
+import org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.runtime.CurrentUser;
 import org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.runtime.CurrentUserId;
 import org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.runtime.Guid;
 import org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.runtime.IsOptionSet;
@@ -102,6 +103,7 @@ public class FunctionExtensionInterpreted extends BaseInterpretedExtension
 
 
                 //Runtime
+                Tuples.pair("currentUser__String_1_", CurrentUser::new),
                 Tuples.pair("currentUserId__String_1_", CurrentUserId::new),
                 Tuples.pair("generateGuid__String_1_", Guid::new),
                 Tuples.pair("isOptionSet_String_1__Boolean_1_", IsOptionSet::new),

--- a/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/runtime/CurrentUser.java
+++ b/legend-engine-core/legend-engine-core-pure/legend-engine-pure-code-functions-unclassified/legend-engine-pure-runtime-java-extension-interpreted-functions-unclassified/src/main/java/org/finos/legend/pure/runtime/java/extension/functions/interpreted/natives/runtime/CurrentUser.java
@@ -1,0 +1,41 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.runtime.java.extension.functions.interpreted.natives.runtime;
+
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.map.MutableMap;
+import org.finos.legend.pure.m3.navigation.M3Paths;
+import org.finos.legend.pure.m3.exception.PureExecutionException;
+import org.finos.legend.pure.m3.compiler.Context;
+import org.finos.legend.pure.m3.navigation.ProcessorSupport;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+import org.finos.legend.pure.runtime.java.interpreted.ExecutionSupport;
+import org.finos.legend.pure.runtime.java.interpreted.FunctionExecutionInterpreted;
+import org.finos.legend.pure.runtime.java.interpreted.VariableContext;
+import org.finos.legend.pure.runtime.java.interpreted.natives.core.InstantiationContext;
+import org.finos.legend.pure.runtime.java.interpreted.natives.core.NativeFunction;
+import org.finos.legend.pure.runtime.java.interpreted.profiler.Profiler;
+
+import java.util.Stack;
+
+public class CurrentUser implements NativeFunction
+{
+    @Override
+    public CoreInstance execute(FunctionExecutionInterpreted functionExecution, ListIterable<? extends CoreInstance> params, Stack<MutableMap<String, CoreInstance>> resolvedTypeParameters, Stack<MutableMap<String, CoreInstance>> resolvedMultiplicityParameters, VariableContext variableContext, CoreInstance functionExpressionToUseInStack, Profiler profiler, InstantiationContext instantiationContext, ExecutionSupport executionSupport, Context context, ProcessorSupport processorSupport) throws PureExecutionException
+    {
+        String username = System.getProperty("user.name");
+        return functionExecution.getProcessorSupport().newCoreInstance(username, processorSupport.package_getByUserPath(M3Paths.String), null);
+    }
+}


### PR DESCRIPTION
This PR adds the currentUser function to legend-engine that returns the OS username of the process running.

Implementation follows the same pattern as the currentUserId function in the unclassified functions module, with:
- Pure language function definition
- Java reference implementations for compiled and interpreted modes
- Test cases to verify functionality

Link to Devin run: https://app.devin.ai/sessions/35e74eacfbd1481ba694f3b0d4821505
Requested by: Neema.Raphael@gs.com