### PR TITLE
Add AWS Aurora PostgreSQL with IAM Database Authentication support

### DIFF
--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2025 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-xt-relationalStore-aurora-postgres</artifactId>
+        <version>4.118.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>legend-engine-xt-relationalStore-aurora-postgres-execution</artifactId>
+    <packaging>jar</packaging>
+    <name>Legend Engine - XT - Relational Store - Aurora PostgreSQL - Execution</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan-connection</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-authentication</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-vault-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-identity-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-identity-plainTextUserPassword</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-aurora-postgres-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-authentication-protocol</artifactId>
+        </dependency>
+
+        <!-- AWS SDK for RDS IAM Authentication -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+
+        <!-- PostgreSQL JDBC Driver -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- ECLIPSE COLLECTIONS -->
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+        <!-- ECLIPSE COLLECTIONS -->
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/authentication/flows/AuroraPostgresDatabaseAuthenticationFlowProvider.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/authentication/flows/AuroraPostgresDatabaseAuthenticationFlowProvider.java
@@ -1,0 +1,45 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.authentication.flows;
+
+import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.authentication.DatabaseAuthenticationFlow;
+import org.finos.legend.engine.authentication.provider.AbstractDatabaseAuthenticationFlowProvider;
+import org.finos.legend.engine.authentication.provider.DatabaseAuthenticationFlowProviderConfiguration;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatasourceSpecification;
+
+/**
+ * Provides authentication flows for Aurora PostgreSQL database connections.
+ * 
+ * Currently supports:
+ * - AWS IAM Database Authentication
+ */
+public class AuroraPostgresDatabaseAuthenticationFlowProvider extends AbstractDatabaseAuthenticationFlowProvider
+{
+    private ImmutableList<DatabaseAuthenticationFlow<? extends DatasourceSpecification, ? extends AuthenticationStrategy>> flows()
+    {
+        return Lists.immutable.of(
+                new AuroraPostgresWithIAMAuthFlow()
+        );
+    }
+
+    @Override
+    public void configure(DatabaseAuthenticationFlowProviderConfiguration configuration)
+    {
+        flows().forEach(this::registerFlow);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/authentication/flows/AuroraPostgresWithIAMAuthFlow.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/authentication/flows/AuroraPostgresWithIAMAuthFlow.java
@@ -1,0 +1,222 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.authentication.flows;
+
+import org.finos.legend.engine.authentication.DatabaseAuthenticationFlow;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSDefaultCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSSTSAssumeRoleCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSStaticCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AWSIAMDatabaseAuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.AuroraPostgresDatasourceSpecification;
+import org.finos.legend.engine.shared.core.identity.Credential;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.engine.shared.core.identity.credential.PlaintextUserPasswordCredential;
+import org.finos.legend.engine.shared.core.vault.Vault;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.RdsUtilities;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+/**
+ * Authentication flow for AWS Aurora PostgreSQL using IAM Database Authentication.
+ * 
+ * This flow generates short-lived authentication tokens using AWS IAM credentials.
+ * The token is used as the password when connecting to Aurora PostgreSQL databases
+ * that have IAM database authentication enabled.
+ * 
+ * The generated tokens are valid for 15 minutes and can be reused during that period.
+ * 
+ * Prerequisites:
+ * - Aurora cluster must have IAM database authentication enabled
+ * - Database user must have rds_iam role granted
+ * - IAM principal must have rds-db:connect permission
+ */
+public class AuroraPostgresWithIAMAuthFlow implements DatabaseAuthenticationFlow<AuroraPostgresDatasourceSpecification, AWSIAMDatabaseAuthenticationStrategy>
+{
+    @Override
+    public Class<AuroraPostgresDatasourceSpecification> getDatasourceClass()
+    {
+        return AuroraPostgresDatasourceSpecification.class;
+    }
+
+    @Override
+    public Class<AWSIAMDatabaseAuthenticationStrategy> getAuthenticationStrategyClass()
+    {
+        return AWSIAMDatabaseAuthenticationStrategy.class;
+    }
+
+    @Override
+    public DatabaseType getDatabaseType()
+    {
+        // Aurora PostgreSQL is PostgreSQL-compatible
+        return DatabaseType.Postgres;
+    }
+
+    @Override
+    public Credential makeCredential(
+            Identity identity,
+            AuroraPostgresDatasourceSpecification datasourceSpecification,
+            AWSIAMDatabaseAuthenticationStrategy authenticationStrategy) throws Exception
+    {
+        // Resolve AWS credentials based on the configured credential type
+        AwsCredentialsProvider credentialsProvider = resolveAwsCredentials(
+                authenticationStrategy.awsCredentials,
+                datasourceSpecification.region
+        );
+
+        // Generate the IAM authentication token using AWS RDS utilities
+        RdsUtilities rdsUtilities = RdsUtilities.builder()
+                .region(Region.of(datasourceSpecification.region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+
+        String authToken = rdsUtilities.generateAuthenticationToken(builder -> builder
+                .hostname(datasourceSpecification.host)
+                .port(datasourceSpecification.port)
+                .username(authenticationStrategy.databaseUsername)
+        );
+
+        // Return the credential with the database username and the IAM token as password
+        return new PlaintextUserPasswordCredential(
+                authenticationStrategy.databaseUsername,
+                authToken
+        );
+    }
+
+    /**
+     * Resolves AWS credentials based on the configured credential type.
+     *
+     * @param awsCredentials The AWS credentials configuration
+     * @param region The AWS region for STS operations
+     * @return An AWS credentials provider
+     */
+    private AwsCredentialsProvider resolveAwsCredentials(AWSCredentials awsCredentials, String region) throws Exception
+    {
+        if (awsCredentials == null || awsCredentials instanceof AWSDefaultCredentials)
+        {
+            // Use the default AWS credential chain
+            // This includes environment variables, system properties, 
+            // credential files, instance profiles, etc.
+            return DefaultCredentialsProvider.create();
+        }
+
+        if (awsCredentials instanceof AWSStaticCredentials)
+        {
+            AWSStaticCredentials staticCredentials = (AWSStaticCredentials) awsCredentials;
+            
+            // Resolve credentials from vault
+            String accessKeyId = lookupSecret(staticCredentials.accessKeyId);
+            String secretAccessKey = lookupSecret(staticCredentials.secretAccessKey);
+
+            return StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+            );
+        }
+
+        if (awsCredentials instanceof AWSSTSAssumeRoleCredentials)
+        {
+            AWSSTSAssumeRoleCredentials stsCredentials = (AWSSTSAssumeRoleCredentials) awsCredentials;
+            
+            // First, get the base credentials
+            AwsCredentialsProvider baseProvider = resolveAwsCredentials(
+                    stsCredentials.awsCredentials,
+                    region
+            );
+
+            // Create STS client to assume the role
+            StsClient stsClient = StsClient.builder()
+                    .region(Region.of(region))
+                    .credentialsProvider(baseProvider)
+                    .build();
+
+            // Build the assume role request
+            AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
+                    .roleArn(stsCredentials.roleArn)
+                    .roleSessionName("legend-aurora-postgres-" + System.currentTimeMillis())
+                    .build();
+
+            // Return a credentials provider that assumes the role
+            return StsAssumeRoleCredentialsProvider.builder()
+                    .stsClient(stsClient)
+                    .refreshRequest(assumeRoleRequest)
+                    .build();
+        }
+
+        throw new UnsupportedOperationException(
+                "Unsupported AWS credentials type: " + awsCredentials.getClass().getSimpleName()
+        );
+    }
+
+    /**
+     * Looks up a secret value from the vault.
+     * Supports both CredentialVaultSecret types and plain string references.
+     */
+    private String lookupSecret(Object secret) throws Exception
+    {
+        if (secret == null)
+        {
+            throw new IllegalArgumentException("Secret reference cannot be null");
+        }
+
+        // Handle CredentialVaultSecret types
+        if (secret instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.CredentialVaultSecret)
+        {
+            org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.CredentialVaultSecret vaultSecret =
+                    (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.CredentialVaultSecret) secret;
+
+            if (vaultSecret instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.PropertiesFileSecret)
+            {
+                org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.PropertiesFileSecret propsSecret =
+                        (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.PropertiesFileSecret) vaultSecret;
+                return Vault.INSTANCE.getValue(propsSecret.propertyName);
+            }
+
+            if (vaultSecret instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.EnvironmentCredentialVaultSecret)
+            {
+                org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.EnvironmentCredentialVaultSecret envSecret =
+                        (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.EnvironmentCredentialVaultSecret) vaultSecret;
+                String value = System.getenv(envSecret.envVariableName);
+                if (value == null)
+                {
+                    throw new IllegalArgumentException("Environment variable not found: " + envSecret.envVariableName);
+                }
+                return value;
+            }
+
+            if (vaultSecret instanceof org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.SystemPropertiesSecret)
+            {
+                org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.SystemPropertiesSecret sysSecret =
+                        (org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.SystemPropertiesSecret) vaultSecret;
+                String value = System.getProperty(sysSecret.systemPropertyName);
+                if (value == null)
+                {
+                    throw new IllegalArgumentException("System property not found: " + sysSecret.systemPropertyName);
+                }
+                return value;
+            }
+        }
+
+        throw new UnsupportedOperationException(
+                "Unsupported secret type: " + secret.getClass().getSimpleName()
+        );
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/AWSIAMDatabaseAuthenticationStrategyKey.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/AWSIAMDatabaseAuthenticationStrategyKey.java
@@ -1,0 +1,72 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational;
+
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.keys.AuthenticationStrategyKey;
+
+import java.util.Objects;
+
+/**
+ * Authentication strategy key for AWS IAM Database Authentication.
+ */
+public class AWSIAMDatabaseAuthenticationStrategyKey implements AuthenticationStrategyKey
+{
+    private final String databaseUsername;
+
+    public AWSIAMDatabaseAuthenticationStrategyKey(String databaseUsername)
+    {
+        this.databaseUsername = databaseUsername;
+    }
+
+    public String getDatabaseUsername()
+    {
+        return databaseUsername;
+    }
+
+    @Override
+    public String shortId()
+    {
+        return "AWSIAMDatabase_user:" + databaseUsername;
+    }
+
+    @Override
+    public String type()
+    {
+        return "AWSIAMDatabase";
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AWSIAMDatabaseAuthenticationStrategyKey that = (AWSIAMDatabaseAuthenticationStrategyKey) o;
+        return Objects.equals(databaseUsername, that.databaseUsername);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(databaseUsername);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AWSIAMDatabaseAuthenticationStrategyKey{" +
+                "databaseUsername='" + databaseUsername + '\'' +
+                '}';
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/AuroraPostgresConnectionExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/AuroraPostgresConnectionExtension.java
@@ -1,0 +1,134 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational;
+
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ConnectionExtension;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ConnectionKey;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.AuthenticationStrategy;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.OAuthProfile;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.keys.AuthenticationStrategyKey;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.DatabaseManager;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.aurorapostgres.AuroraPostgresManager;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.DataSourceSpecification;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.DataSourceSpecificationKey;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications.AuroraPostgresDataSourceSpecification;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications.keys.AuroraPostgresDataSourceSpecificationKey;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.manager.strategic.StrategicConnectionExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.RelationalDatabaseConnection;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AWSIAMDatabaseAuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AuthenticationStrategyVisitor;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.AuroraPostgresDatasourceSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatasourceSpecificationVisitor;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Connection extension for Aurora PostgreSQL databases.
+ * 
+ * Provides the necessary components for Legend to connect to Aurora PostgreSQL
+ * databases using IAM authentication.
+ */
+public class AuroraPostgresConnectionExtension implements ConnectionExtension, StrategicConnectionExtension
+{
+    @Override
+    public String type()
+    {
+        return "AuroraPostgres_ConnectionExtension";
+    }
+
+    @Override
+    public MutableList<String> group()
+    {
+        return Lists.mutable.with("Store", "Relational", "AuroraPostgres");
+    }
+
+    @Override
+    public MutableList<DatabaseManager> getAdditionalDatabaseManager()
+    {
+        return Lists.mutable.of(new AuroraPostgresManager());
+    }
+
+    @Override
+    public AuthenticationStrategyVisitor<AuthenticationStrategyKey> getExtraAuthenticationKeyGenerators()
+    {
+        return authenticationStrategy ->
+        {
+            if (authenticationStrategy instanceof AWSIAMDatabaseAuthenticationStrategy)
+            {
+                AWSIAMDatabaseAuthenticationStrategy strategy = (AWSIAMDatabaseAuthenticationStrategy) authenticationStrategy;
+                return new AWSIAMDatabaseAuthenticationStrategyKey(strategy.databaseUsername);
+            }
+            return null;
+        };
+    }
+
+    @Override
+    public AuthenticationStrategyVisitor<AuthenticationStrategy> getExtraAuthenticationStrategyTransformGenerators(List<OAuthProfile> oauthProfiles)
+    {
+        return authenticationStrategy ->
+        {
+            if (authenticationStrategy instanceof AWSIAMDatabaseAuthenticationStrategy)
+            {
+                AWSIAMDatabaseAuthenticationStrategy strategy = (AWSIAMDatabaseAuthenticationStrategy) authenticationStrategy;
+                return new org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.AWSIAMDatabaseAuthenticationStrategy(
+                        strategy.databaseUsername,
+                        strategy.awsCredentials
+                );
+            }
+            return null;
+        };
+    }
+
+    @Override
+    public Function<RelationalDatabaseConnection, DatasourceSpecificationVisitor<DataSourceSpecificationKey>> getExtraDataSourceSpecificationKeyGenerators(int testDbPort)
+    {
+        return connection -> datasourceSpecification ->
+        {
+            if (datasourceSpecification instanceof AuroraPostgresDatasourceSpecification)
+            {
+                AuroraPostgresDatasourceSpecification spec = (AuroraPostgresDatasourceSpecification) datasourceSpecification;
+                return new AuroraPostgresDataSourceSpecificationKey(
+                        spec.host,
+                        spec.port,
+                        spec.databaseName,
+                        spec.region,
+                        spec.clusterIdentifier
+                );
+            }
+            return null;
+        };
+    }
+
+    @Override
+    public Function2<RelationalDatabaseConnection, ConnectionKey, DatasourceSpecificationVisitor<DataSourceSpecification>> getExtraDataSourceSpecificationTransformerGenerators(Function<RelationalDatabaseConnection, AuthenticationStrategy> authenticationStrategyProvider)
+    {
+        return (connection, connectionKey) -> datasourceSpecification ->
+        {
+            if (datasourceSpecification instanceof AuroraPostgresDatasourceSpecification)
+            {
+                return new AuroraPostgresDataSourceSpecification(
+                        (AuroraPostgresDataSourceSpecificationKey) connectionKey.getDataSourceSpecificationKey(),
+                        new AuroraPostgresManager(),
+                        authenticationStrategyProvider.apply(connection)
+                );
+            }
+            return null;
+        };
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/AWSIAMDatabaseAuthenticationStrategy.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/authentication/strategy/AWSIAMDatabaseAuthenticationStrategy.java
@@ -1,0 +1,158 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy;
+
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.engine.plan.execution.stores.relational.AWSIAMDatabaseAuthenticationStrategyKey;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ConnectionException;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.AuthenticationStrategy;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.strategy.keys.AuthenticationStrategyKey;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.DataSourceWithStatistics;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.DatabaseManager;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.aurorapostgres.AuroraPostgresManager;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSCredentials;
+import org.finos.legend.engine.shared.core.identity.Identity;
+import org.finos.legend.engine.shared.core.identity.credential.PlaintextUserPasswordCredential;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.RdsUtilities;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ * Runtime authentication strategy for AWS IAM Database Authentication.
+ * 
+ * This strategy generates IAM authentication tokens at connection time
+ * and uses them as passwords for database connections.
+ */
+public class AWSIAMDatabaseAuthenticationStrategy extends AuthenticationStrategy
+{
+    private final String databaseUsername;
+    private final AWSCredentials awsCredentials;
+
+    public AWSIAMDatabaseAuthenticationStrategy(String databaseUsername, AWSCredentials awsCredentials)
+    {
+        this.databaseUsername = databaseUsername;
+        this.awsCredentials = awsCredentials;
+    }
+
+    @Override
+    public Connection getConnectionImpl(DataSourceWithStatistics ds, Identity identity) throws ConnectionException
+    {
+        try
+        {
+            return ds.getDataSource().getConnection();
+        }
+        catch (SQLException e)
+        {
+            throw new ConnectionException(e);
+        }
+    }
+
+    @Override
+    public Pair<String, Properties> handleConnection(String url, Properties properties, DatabaseManager databaseManager)
+    {
+        Properties connectionProperties = new Properties();
+        connectionProperties.putAll(properties);
+
+        // Get the region from datasource properties
+        String region = properties.getProperty(AuroraPostgresManager.AURORA_REGION, "us-east-1");
+
+        // Extract host and port from URL
+        // URL format: jdbc:postgresql://host:port/database?params
+        String host = extractHostFromUrl(url);
+        int port = extractPortFromUrl(url);
+
+        // Generate the IAM authentication token
+        AwsCredentialsProvider credentialsProvider = resolveCredentials();
+        
+        RdsUtilities rdsUtilities = RdsUtilities.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
+                .build();
+
+        String authToken = rdsUtilities.generateAuthenticationToken(builder -> builder
+                .hostname(host)
+                .port(port)
+                .username(databaseUsername)
+        );
+
+        connectionProperties.put("user", databaseUsername);
+        connectionProperties.put("password", authToken);
+
+        return Tuples.pair(url, connectionProperties);
+    }
+
+    @Override
+    public AuthenticationStrategyKey getKey()
+    {
+        return new AWSIAMDatabaseAuthenticationStrategyKey(databaseUsername);
+    }
+
+    private AwsCredentialsProvider resolveCredentials()
+    {
+        // For now, use default credentials provider
+        // The full implementation would handle all AWS credential types
+        return DefaultCredentialsProvider.create();
+    }
+
+    private String extractHostFromUrl(String url)
+    {
+        // jdbc:postgresql://host:port/database
+        String withoutPrefix = url.replace("jdbc:postgresql://", "");
+        int colonIndex = withoutPrefix.indexOf(':');
+        if (colonIndex > 0)
+        {
+            return withoutPrefix.substring(0, colonIndex);
+        }
+        int slashIndex = withoutPrefix.indexOf('/');
+        if (slashIndex > 0)
+        {
+            return withoutPrefix.substring(0, slashIndex);
+        }
+        return withoutPrefix;
+    }
+
+    private int extractPortFromUrl(String url)
+    {
+        // jdbc:postgresql://host:port/database
+        String withoutPrefix = url.replace("jdbc:postgresql://", "");
+        int colonIndex = withoutPrefix.indexOf(':');
+        if (colonIndex > 0)
+        {
+            int slashIndex = withoutPrefix.indexOf('/');
+            String portStr = withoutPrefix.substring(colonIndex + 1, slashIndex > colonIndex ? slashIndex : withoutPrefix.length());
+            // Handle query parameters
+            int questionIndex = portStr.indexOf('?');
+            if (questionIndex > 0)
+            {
+                portStr = portStr.substring(0, questionIndex);
+            }
+            try
+            {
+                return Integer.parseInt(portStr);
+            }
+            catch (NumberFormatException e)
+            {
+                return 5432; // Default PostgreSQL port
+            }
+        }
+        return 5432;
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/aurorapostgres/AuroraPostgresCommands.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/aurorapostgres/AuroraPostgresCommands.java
@@ -1,0 +1,55 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.aurorapostgres;
+
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.Column;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.IngestionMethod;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.RelationalDatabaseCommands;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.RelationalDatabaseCommandsVisitor;
+
+import java.util.List;
+
+/**
+ * SQL commands for Aurora PostgreSQL.
+ * 
+ * Aurora PostgreSQL is compatible with standard PostgreSQL,
+ * so all commands follow PostgreSQL syntax.
+ */
+public class AuroraPostgresCommands extends RelationalDatabaseCommands
+{
+    @Override
+    public String dropTempTable(String tableName)
+    {
+        return "DROP TABLE IF EXISTS " + tableName;
+    }
+
+    @Override
+    public List<String> createAndLoadTempTable(String tableName, List<Column> columns, String optionalCSVFileLocation)
+    {
+        throw new UnsupportedOperationException("Not implemented for Aurora PostgreSQL");
+    }
+
+    @Override
+    public IngestionMethod getDefaultIngestionMethod()
+    {
+        return IngestionMethod.CLIENT_FILE;
+    }
+
+    @Override
+    public <T> T accept(RelationalDatabaseCommandsVisitor<T> visitor)
+    {
+        return visitor.visit(this);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/aurorapostgres/AuroraPostgresDriver.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/aurorapostgres/AuroraPostgresDriver.java
@@ -1,0 +1,33 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.aurorapostgres;
+
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.DriverWrapper;
+
+/**
+ * JDBC driver wrapper for Aurora PostgreSQL.
+ * 
+ * Aurora PostgreSQL uses the standard PostgreSQL JDBC driver under the hood.
+ * This wrapper enables Legend's connection management and authentication
+ * strategy interception.
+ */
+public class AuroraPostgresDriver extends DriverWrapper
+{
+    @Override
+    protected String getClassName()
+    {
+        return "org.postgresql.Driver";
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/aurorapostgres/AuroraPostgresManager.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/driver/vendors/aurorapostgres/AuroraPostgresManager.java
@@ -1,0 +1,64 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.aurorapostgres;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.AuthenticationStrategy;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.DatabaseManager;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.commands.RelationalDatabaseCommands;
+
+import java.util.Properties;
+
+/**
+ * Database manager for AWS Aurora PostgreSQL.
+ * 
+ * Aurora PostgreSQL uses the standard PostgreSQL JDBC driver but requires
+ * SSL for IAM authentication. The connection URL format is the same as
+ * PostgreSQL with SSL parameters enabled.
+ */
+public class AuroraPostgresManager extends DatabaseManager
+{
+    public static final String AURORA_REGION = "auroraRegion";
+    public static final String AURORA_CLUSTER_ID = "auroraClusterIdentifier";
+
+    @Override
+    public MutableList<String> getIds()
+    {
+        return Lists.mutable.with("AuroraPostgres");
+    }
+
+    @Override
+    public String buildURL(String host, int port, String databaseName, Properties extraUserDataSourceProperties, AuthenticationStrategy authenticationStrategy)
+    {
+        // Aurora PostgreSQL requires SSL for IAM authentication
+        // sslmode=require ensures encrypted connection
+        // sslrootcert can be used to specify the RDS CA certificate
+        return "jdbc:postgresql://" + host + ":" + port + "/" + databaseName + 
+               "?ssl=true&sslmode=require";
+    }
+
+    @Override
+    public String getDriver()
+    {
+        return "org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.aurorapostgres.AuroraPostgresDriver";
+    }
+
+    @Override
+    public RelationalDatabaseCommands relationalDatabaseSupport()
+    {
+        return new AuroraPostgresCommands();
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/AuroraPostgresDataSourceSpecification.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/AuroraPostgresDataSourceSpecification.java
@@ -1,0 +1,64 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications;
+
+import org.finos.legend.engine.plan.execution.stores.relational.connection.authentication.AuthenticationStrategy;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.DatabaseManager;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.driver.vendors.aurorapostgres.AuroraPostgresManager;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.DataSourceSpecification;
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications.keys.AuroraPostgresDataSourceSpecificationKey;
+
+import java.util.Properties;
+
+/**
+ * Data source specification for Aurora PostgreSQL connections.
+ */
+public class AuroraPostgresDataSourceSpecification extends DataSourceSpecification
+{
+    public AuroraPostgresDataSourceSpecification(
+            AuroraPostgresDataSourceSpecificationKey key,
+            DatabaseManager databaseManager,
+            AuthenticationStrategy authenticationStrategy)
+    {
+        this(key, databaseManager, authenticationStrategy, createProperties(key));
+    }
+
+    private AuroraPostgresDataSourceSpecification(
+            AuroraPostgresDataSourceSpecificationKey key,
+            DatabaseManager databaseManager,
+            AuthenticationStrategy authenticationStrategy,
+            Properties extraUserProperties)
+    {
+        super(key, databaseManager, authenticationStrategy, extraUserProperties);
+    }
+
+    private static Properties createProperties(AuroraPostgresDataSourceSpecificationKey key)
+    {
+        Properties props = new Properties();
+        props.put(AuroraPostgresManager.AURORA_REGION, key.getRegion());
+        if (key.getClusterIdentifier() != null)
+        {
+            props.put(AuroraPostgresManager.AURORA_CLUSTER_ID, key.getClusterIdentifier());
+        }
+        return props;
+    }
+
+    @Override
+    protected String getJdbcUrl(String host, int port, String databaseName, Properties properties)
+    {
+        AuroraPostgresDataSourceSpecificationKey key = (AuroraPostgresDataSourceSpecificationKey) this.datasourceKey;
+        return super.getJdbcUrl(key.getHost(), key.getPort(), key.getDatabaseName(), properties);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/keys/AuroraPostgresDataSourceSpecificationKey.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/java/org/finos/legend/engine/plan/execution/stores/relational/connection/ds/specifications/keys/AuroraPostgresDataSourceSpecificationKey.java
@@ -1,0 +1,106 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.plan.execution.stores.relational.connection.ds.specifications.keys;
+
+import org.finos.legend.engine.plan.execution.stores.relational.connection.ds.DataSourceSpecificationKey;
+
+import java.util.Objects;
+
+/**
+ * Key for identifying and caching Aurora PostgreSQL data source connections.
+ */
+public class AuroraPostgresDataSourceSpecificationKey implements DataSourceSpecificationKey
+{
+    private final String host;
+    private final int port;
+    private final String databaseName;
+    private final String region;
+    private final String clusterIdentifier;
+
+    public AuroraPostgresDataSourceSpecificationKey(String host, int port, String databaseName, String region, String clusterIdentifier)
+    {
+        this.host = host;
+        this.port = port;
+        this.databaseName = databaseName;
+        this.region = region;
+        this.clusterIdentifier = clusterIdentifier;
+    }
+
+    public String getHost()
+    {
+        return host;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    public String getDatabaseName()
+    {
+        return databaseName;
+    }
+
+    public String getRegion()
+    {
+        return region;
+    }
+
+    public String getClusterIdentifier()
+    {
+        return clusterIdentifier;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AuroraPostgresDataSourceSpecificationKey{" +
+                "host='" + host + '\'' +
+                ", port=" + port +
+                ", databaseName='" + databaseName + '\'' +
+                ", region='" + region + '\'' +
+                ", clusterIdentifier='" + clusterIdentifier + '\'' +
+                '}';
+    }
+
+    @Override
+    public String shortId()
+    {
+        return "AuroraPostgres_" +
+                "host:" + host + "_" +
+                "port:" + port + "_" +
+                "db:" + databaseName + "_" +
+                "region:" + region;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AuroraPostgresDataSourceSpecificationKey that = (AuroraPostgresDataSourceSpecificationKey) o;
+        return port == that.port &&
+                Objects.equals(host, that.host) &&
+                Objects.equals(databaseName, that.databaseName) &&
+                Objects.equals(region, that.region) &&
+                Objects.equals(clusterIdentifier, that.clusterIdentifier);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(host, port, databaseName, region, clusterIdentifier);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/resources/META-INF/services/org.finos.legend.engine.authentication.provider.DatabaseAuthenticationFlowProvider
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/resources/META-INF/services/org.finos.legend.engine.authentication.provider.DatabaseAuthenticationFlowProvider
@@ -1,0 +1,1 @@
+org.finos.legend.engine.authentication.flows.AuroraPostgresDatabaseAuthenticationFlowProvider

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/resources/META-INF/services/org.finos.legend.engine.plan.execution.stores.relational.connection.ConnectionExtension
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/resources/META-INF/services/org.finos.legend.engine.plan.execution.stores.relational.connection.ConnectionExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.plan.execution.stores.relational.AuroraPostgresConnectionExtension

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/resources/META-INF/services/org.finos.legend.engine.plan.execution.stores.relational.connection.manager.strategic.StrategicConnectionExtension
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-execution/src/main/resources/META-INF/services/org.finos.legend.engine.plan.execution.stores.relational.connection.manager.strategic.StrategicConnectionExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.plan.execution.stores.relational.AuroraPostgresConnectionExtension

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2025 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-xt-relationalStore-aurora-postgres</artifactId>
+        <version>4.118.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>legend-engine-xt-relationalStore-aurora-postgres-grammar</artifactId>
+    <packaging>jar</packaging>
+    <name>Legend Engine - XT - Relational Store - Aurora PostgreSQL - Grammar</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-aurora-postgres-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-grammar</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-aurora-postgres-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-authentication-protocol</artifactId>
+        </dependency>
+
+        <!-- ANTLR -->
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+        </dependency>
+
+        <!-- ECLIPSE COLLECTIONS -->
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+        <!-- ECLIPSE COLLECTIONS -->
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/AuroraPostgresLexerGrammar.g4
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/AuroraPostgresLexerGrammar.g4
@@ -1,0 +1,20 @@
+lexer grammar AuroraPostgresLexerGrammar;
+
+import CoreLexerGrammar;
+
+AURORA_POSTGRES:                        'AuroraPostgres';
+HOST:                                   'host';
+PORT:                                   'port';
+NAME:                                   'name';
+REGION:                                 'region';
+CLUSTER_IDENTIFIER:                     'clusterIdentifier';
+
+AWS_IAM_DATABASE:                       'AWSIAMDatabase';
+DATABASE_USERNAME:                      'databaseUsername';
+AWS_CREDENTIALS:                        'awsCredentials';
+DEFAULT:                                'Default';
+STATIC:                                 'Static';
+STS_ASSUME_ROLE:                        'STSAssumeRole';
+ACCESS_KEY_ID:                          'accessKeyId';
+SECRET_ACCESS_KEY:                      'secretAccessKey';
+ROLE_ARN:                               'roleArn';

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/AuroraPostgresParserGrammar.g4
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/connection/AuroraPostgresParserGrammar.g4
@@ -1,0 +1,89 @@
+parser grammar AuroraPostgresParserGrammar;
+
+import CoreParserGrammar;
+
+options
+{
+    tokenVocab = AuroraPostgresLexerGrammar;
+}
+
+// ----------------------------- Aurora PostgreSQL Datasource Specification -----------------------------
+
+auroraPostgresDatasourceSpecification:  AURORA_POSTGRES
+                                        BRACE_OPEN
+                                            (
+                                                dbHost
+                                                | dbPort
+                                                | dbName
+                                                | region
+                                                | clusterIdentifier
+                                            )*
+                                        BRACE_CLOSE
+;
+
+dbHost:                                 HOST COLON STRING SEMI_COLON
+;
+
+dbPort:                                 PORT COLON INTEGER SEMI_COLON
+;
+
+dbName:                                 NAME COLON STRING SEMI_COLON
+;
+
+region:                                 REGION COLON STRING SEMI_COLON
+;
+
+clusterIdentifier:                      CLUSTER_IDENTIFIER COLON STRING SEMI_COLON
+;
+
+// ----------------------------- AWS IAM Database Authentication Strategy -----------------------------
+
+awsIAMDatabaseAuthenticationStrategy:   AWS_IAM_DATABASE
+                                        BRACE_OPEN
+                                            (
+                                                databaseUsername
+                                                | awsCredentials
+                                            )*
+                                        BRACE_CLOSE
+;
+
+databaseUsername:                       DATABASE_USERNAME COLON STRING SEMI_COLON
+;
+
+awsCredentials:                         AWS_CREDENTIALS COLON awsCredentialsValue SEMI_COLON
+;
+
+awsCredentialsValue:                    awsDefaultCredentials
+                                        | awsStaticCredentials
+                                        | awsStsAssumeRoleCredentials
+;
+
+awsDefaultCredentials:                  DEFAULT BRACE_OPEN BRACE_CLOSE
+;
+
+awsStaticCredentials:                   STATIC
+                                        BRACE_OPEN
+                                            (
+                                                accessKeyId
+                                                | secretAccessKey
+                                            )*
+                                        BRACE_CLOSE
+;
+
+awsStsAssumeRoleCredentials:            STS_ASSUME_ROLE
+                                        BRACE_OPEN
+                                            (
+                                                roleArn
+                                                | awsCredentials
+                                            )*
+                                        BRACE_CLOSE
+;
+
+accessKeyId:                            ACCESS_KEY_ID COLON STRING SEMI_COLON
+;
+
+secretAccessKey:                        SECRET_ACCESS_KEY COLON STRING SEMI_COLON
+;
+
+roleArn:                                ROLE_ARN COLON STRING SEMI_COLON
+;

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/AuroraPostgresCompilerExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/AuroraPostgresCompilerExtension.java
@@ -1,0 +1,111 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.compiler.toPureGraph;
+
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.DatabaseType;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AWSIAMDatabaseAuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.flows.DatabaseAuthenticationFlowKey;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.AuroraPostgresDatasourceSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatasourceSpecification;
+import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_alloy_authentication_AuthenticationStrategy;
+import org.finos.legend.pure.generated.Root_meta_pure_alloy_connections_alloy_specification_DatasourceSpecification;
+import org.finos.legend.pure.generated.Root_meta_pure_legend_connections_legend_specification_AuroraPostgresDatasourceSpecification;
+import org.finos.legend.pure.generated.Root_meta_pure_legend_connections_legend_specification_AuroraPostgresDatasourceSpecification_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_legend_connections_legend_authentication_AWSIAMDatabaseAuthenticationStrategy;
+import org.finos.legend.pure.generated.Root_meta_pure_legend_connections_legend_authentication_AWSIAMDatabaseAuthenticationStrategy_Impl;
+
+import java.util.List;
+
+public class AuroraPostgresCompilerExtension implements IRelationalCompilerExtension
+{
+    @Override
+    public MutableList<String> group()
+    {
+        return Lists.mutable.with("Store", "Relational", "AuroraPostgres");
+    }
+
+    @Override
+    public CompilerExtension build()
+    {
+        return new AuroraPostgresCompilerExtension();
+    }
+
+    @Override
+    public List<Function2<DatasourceSpecification, CompileContext, Root_meta_pure_alloy_connections_alloy_specification_DatasourceSpecification>> getExtraDataSourceSpecificationProcessors()
+    {
+        return Lists.mutable.with((datasourceSpecification, context) ->
+        {
+            if (datasourceSpecification instanceof AuroraPostgresDatasourceSpecification)
+            {
+                AuroraPostgresDatasourceSpecification spec = (AuroraPostgresDatasourceSpecification) datasourceSpecification;
+                Root_meta_pure_legend_connections_legend_specification_AuroraPostgresDatasourceSpecification pureSpec = 
+                        new Root_meta_pure_legend_connections_legend_specification_AuroraPostgresDatasourceSpecification_Impl(
+                                "", 
+                                null, 
+                                context.pureModel.getClass("meta::pure::legend::connections::legend::specification::AuroraPostgresDatasourceSpecification")
+                        );
+                pureSpec._host(spec.host);
+                pureSpec._port(spec.port);
+                pureSpec._databaseName(spec.databaseName);
+                pureSpec._region(spec.region);
+                if (spec.clusterIdentifier != null)
+                {
+                    pureSpec._clusterIdentifier(spec.clusterIdentifier);
+                }
+                return pureSpec;
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public List<Function2<AuthenticationStrategy, CompileContext, Root_meta_pure_alloy_connections_alloy_authentication_AuthenticationStrategy>> getExtraAuthenticationStrategyProcessors()
+    {
+        return Lists.mutable.with((authenticationStrategy, context) ->
+        {
+            if (authenticationStrategy instanceof AWSIAMDatabaseAuthenticationStrategy)
+            {
+                AWSIAMDatabaseAuthenticationStrategy strategy = (AWSIAMDatabaseAuthenticationStrategy) authenticationStrategy;
+                Root_meta_pure_legend_connections_legend_authentication_AWSIAMDatabaseAuthenticationStrategy pureStrategy = 
+                        new Root_meta_pure_legend_connections_legend_authentication_AWSIAMDatabaseAuthenticationStrategy_Impl(
+                                "", 
+                                null, 
+                                context.pureModel.getClass("meta::pure::legend::connections::legend::authentication::AWSIAMDatabaseAuthenticationStrategy")
+                        );
+                pureStrategy._databaseUsername(strategy.databaseUsername);
+                // AWS credentials would need to be compiled as well - simplified for now
+                return pureStrategy;
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public List<DatabaseAuthenticationFlowKey> getFlowKeys()
+    {
+        return Lists.mutable.of(
+                DatabaseAuthenticationFlowKey.newKey(
+                        DatabaseType.Postgres,
+                        AuroraPostgresDatasourceSpecification.class,
+                        AWSIAMDatabaseAuthenticationStrategy.class
+                )
+        );
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/AuroraPostgresGrammarParserExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/AuroraPostgresGrammarParserExtension.java
@@ -1,0 +1,195 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.from;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.language.pure.grammar.from.antlr4.connection.AuroraPostgresLexerGrammar;
+import org.finos.legend.engine.language.pure.grammar.from.antlr4.connection.AuroraPostgresParserGrammar;
+import org.finos.legend.engine.language.pure.grammar.from.authentication.AuthenticationStrategySourceCode;
+import org.finos.legend.engine.language.pure.grammar.from.datasource.DataSourceSpecificationSourceCode;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSDefaultCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSSTSAssumeRoleCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSStaticCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.PropertiesFileSecret;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AWSIAMDatabaseAuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.AuroraPostgresDatasourceSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatasourceSpecification;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+public class AuroraPostgresGrammarParserExtension implements IRelationalGrammarParserExtension
+{
+    @Override
+    public MutableList<String> group()
+    {
+        return Lists.mutable.with("Store", "Relational", "AuroraPostgres");
+    }
+
+    @Override
+    public List<Function<DataSourceSpecificationSourceCode, DatasourceSpecification>> getExtraDataSourceSpecificationParsers()
+    {
+        return Collections.singletonList(code ->
+        {
+            if ("AuroraPostgres".equals(code.getType()))
+            {
+                return IRelationalGrammarParserExtension.parse(
+                        code,
+                        AuroraPostgresLexerGrammar::new,
+                        AuroraPostgresParserGrammar::new,
+                        p -> visitAuroraPostgresDatasourceSpecification(p.auroraPostgresDatasourceSpecification())
+                );
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public List<Function<AuthenticationStrategySourceCode, AuthenticationStrategy>> getExtraAuthenticationStrategyParsers()
+    {
+        return Collections.singletonList(code ->
+        {
+            if ("AWSIAMDatabase".equals(code.getType()))
+            {
+                return IRelationalGrammarParserExtension.parse(
+                        code,
+                        AuroraPostgresLexerGrammar::new,
+                        AuroraPostgresParserGrammar::new,
+                        p -> visitAWSIAMDatabaseAuthenticationStrategy(p.awsIAMDatabaseAuthenticationStrategy())
+                );
+            }
+            return null;
+        });
+    }
+
+    private AuroraPostgresDatasourceSpecification visitAuroraPostgresDatasourceSpecification(
+            AuroraPostgresParserGrammar.AuroraPostgresDatasourceSpecificationContext ctx)
+    {
+        AuroraPostgresDatasourceSpecification spec = new AuroraPostgresDatasourceSpecification();
+
+        AuroraPostgresParserGrammar.DbHostContext hostCtx = 
+                PureGrammarParserUtility.validateAndExtractRequiredField(ctx.dbHost(), "host", spec.sourceInformation);
+        AuroraPostgresParserGrammar.DbPortContext portCtx = 
+                PureGrammarParserUtility.validateAndExtractRequiredField(ctx.dbPort(), "port", spec.sourceInformation);
+        AuroraPostgresParserGrammar.DbNameContext nameCtx = 
+                PureGrammarParserUtility.validateAndExtractRequiredField(ctx.dbName(), "name", spec.sourceInformation);
+        AuroraPostgresParserGrammar.RegionContext regionCtx = 
+                PureGrammarParserUtility.validateAndExtractRequiredField(ctx.region(), "region", spec.sourceInformation);
+        AuroraPostgresParserGrammar.ClusterIdentifierContext clusterCtx = 
+                PureGrammarParserUtility.validateAndExtractOptionalField(ctx.clusterIdentifier(), "clusterIdentifier", spec.sourceInformation);
+
+        spec.host = PureGrammarParserUtility.fromGrammarString(hostCtx.STRING().getText(), true);
+        spec.port = Integer.parseInt(portCtx.INTEGER().getText());
+        spec.databaseName = PureGrammarParserUtility.fromGrammarString(nameCtx.STRING().getText(), true);
+        spec.region = PureGrammarParserUtility.fromGrammarString(regionCtx.STRING().getText(), true);
+        
+        if (clusterCtx != null)
+        {
+            spec.clusterIdentifier = PureGrammarParserUtility.fromGrammarString(clusterCtx.STRING().getText(), true);
+        }
+
+        return spec;
+    }
+
+    private AWSIAMDatabaseAuthenticationStrategy visitAWSIAMDatabaseAuthenticationStrategy(
+            AuroraPostgresParserGrammar.AwsIAMDatabaseAuthenticationStrategyContext ctx)
+    {
+        AWSIAMDatabaseAuthenticationStrategy strategy = new AWSIAMDatabaseAuthenticationStrategy();
+
+        AuroraPostgresParserGrammar.DatabaseUsernameContext usernameCtx = 
+                PureGrammarParserUtility.validateAndExtractRequiredField(ctx.databaseUsername(), "databaseUsername", strategy.sourceInformation);
+        AuroraPostgresParserGrammar.AwsCredentialsContext credentialsCtx = 
+                PureGrammarParserUtility.validateAndExtractOptionalField(ctx.awsCredentials(), "awsCredentials", strategy.sourceInformation);
+
+        strategy.databaseUsername = PureGrammarParserUtility.fromGrammarString(usernameCtx.STRING().getText(), true);
+        
+        if (credentialsCtx != null)
+        {
+            strategy.awsCredentials = visitAwsCredentials(credentialsCtx.awsCredentialsValue());
+        }
+        else
+        {
+            // Default to AWSDefaultCredentials if not specified
+            strategy.awsCredentials = new AWSDefaultCredentials();
+        }
+
+        return strategy;
+    }
+
+    private AWSCredentials visitAwsCredentials(AuroraPostgresParserGrammar.AwsCredentialsValueContext ctx)
+    {
+        if (ctx.awsDefaultCredentials() != null)
+        {
+            return new AWSDefaultCredentials();
+        }
+        if (ctx.awsStaticCredentials() != null)
+        {
+            return visitAwsStaticCredentials(ctx.awsStaticCredentials());
+        }
+        if (ctx.awsStsAssumeRoleCredentials() != null)
+        {
+            return visitAwsStsAssumeRoleCredentials(ctx.awsStsAssumeRoleCredentials());
+        }
+        throw new RuntimeException("Unsupported AWS credentials type");
+    }
+
+    private AWSStaticCredentials visitAwsStaticCredentials(AuroraPostgresParserGrammar.AwsStaticCredentialsContext ctx)
+    {
+        AWSStaticCredentials credentials = new AWSStaticCredentials();
+
+        AuroraPostgresParserGrammar.AccessKeyIdContext accessKeyCtx = 
+                PureGrammarParserUtility.validateAndExtractRequiredField(ctx.accessKeyId(), "accessKeyId", null);
+        AuroraPostgresParserGrammar.SecretAccessKeyContext secretKeyCtx = 
+                PureGrammarParserUtility.validateAndExtractRequiredField(ctx.secretAccessKey(), "secretAccessKey", null);
+
+        // For now, use PropertiesFileSecret for the vault references
+        PropertiesFileSecret accessKeySecret = new PropertiesFileSecret();
+        accessKeySecret.propertyName = PureGrammarParserUtility.fromGrammarString(accessKeyCtx.STRING().getText(), true);
+        credentials.accessKeyId = accessKeySecret;
+
+        PropertiesFileSecret secretKeySecret = new PropertiesFileSecret();
+        secretKeySecret.propertyName = PureGrammarParserUtility.fromGrammarString(secretKeyCtx.STRING().getText(), true);
+        credentials.secretAccessKey = secretKeySecret;
+
+        return credentials;
+    }
+
+    private AWSSTSAssumeRoleCredentials visitAwsStsAssumeRoleCredentials(AuroraPostgresParserGrammar.AwsStsAssumeRoleCredentialsContext ctx)
+    {
+        AWSSTSAssumeRoleCredentials credentials = new AWSSTSAssumeRoleCredentials();
+
+        AuroraPostgresParserGrammar.RoleArnContext roleArnCtx = 
+                PureGrammarParserUtility.validateAndExtractRequiredField(ctx.roleArn(), "roleArn", null);
+        AuroraPostgresParserGrammar.AwsCredentialsContext baseCredentialsCtx = 
+                PureGrammarParserUtility.validateAndExtractOptionalField(ctx.awsCredentials(), "awsCredentials", null);
+
+        credentials.roleArn = PureGrammarParserUtility.fromGrammarString(roleArnCtx.STRING().getText(), true);
+        
+        if (baseCredentialsCtx != null)
+        {
+            credentials.awsCredentials = visitAwsCredentials(baseCredentialsCtx.awsCredentialsValue());
+        }
+        else
+        {
+            credentials.awsCredentials = new AWSDefaultCredentials();
+        }
+
+        return credentials;
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/AuroraPostgresGrammarComposerExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/AuroraPostgresGrammarComposerExtension.java
@@ -1,0 +1,141 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.language.pure.grammar.to;
+
+import org.eclipse.collections.api.block.function.Function2;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSDefaultCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSSTSAssumeRoleCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSStaticCredentials;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.CredentialVaultSecret;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.PropertiesFileSecret;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AWSIAMDatabaseAuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.AuroraPostgresDatasourceSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatasourceSpecification;
+
+import java.util.List;
+
+import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.convertString;
+import static org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerUtility.getTabString;
+
+public class AuroraPostgresGrammarComposerExtension implements IRelationalGrammarComposerExtension
+{
+    @Override
+    public MutableList<String> group()
+    {
+        return Lists.mutable.with("Store", "Relational", "AuroraPostgres");
+    }
+
+    @Override
+    public List<Function2<DatasourceSpecification, PureGrammarComposerContext, String>> getExtraDataSourceSpecificationComposers()
+    {
+        return Lists.mutable.with((spec, context) ->
+        {
+            if (spec instanceof AuroraPostgresDatasourceSpecification)
+            {
+                AuroraPostgresDatasourceSpecification auroraSpec = (AuroraPostgresDatasourceSpecification) spec;
+                int baseIndentation = 1;
+                StringBuilder builder = new StringBuilder();
+                builder.append("AuroraPostgres\n");
+                builder.append(context.getIndentationString()).append(getTabString(baseIndentation)).append("{\n");
+                builder.append(context.getIndentationString()).append(getTabString(baseIndentation + 1)).append("host: ").append(convertString(auroraSpec.host, true)).append(";\n");
+                builder.append(context.getIndentationString()).append(getTabString(baseIndentation + 1)).append("port: ").append(auroraSpec.port).append(";\n");
+                builder.append(context.getIndentationString()).append(getTabString(baseIndentation + 1)).append("name: ").append(convertString(auroraSpec.databaseName, true)).append(";\n");
+                builder.append(context.getIndentationString()).append(getTabString(baseIndentation + 1)).append("region: ").append(convertString(auroraSpec.region, true)).append(";\n");
+                if (auroraSpec.clusterIdentifier != null && !auroraSpec.clusterIdentifier.isEmpty())
+                {
+                    builder.append(context.getIndentationString()).append(getTabString(baseIndentation + 1)).append("clusterIdentifier: ").append(convertString(auroraSpec.clusterIdentifier, true)).append(";\n");
+                }
+                builder.append(context.getIndentationString()).append(getTabString(baseIndentation)).append("}");
+                return builder.toString();
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public List<Function2<AuthenticationStrategy, PureGrammarComposerContext, String>> getExtraAuthenticationStrategyComposers()
+    {
+        return Lists.mutable.with((strategy, context) ->
+        {
+            if (strategy instanceof AWSIAMDatabaseAuthenticationStrategy)
+            {
+                AWSIAMDatabaseAuthenticationStrategy iamStrategy = (AWSIAMDatabaseAuthenticationStrategy) strategy;
+                int baseIndentation = 1;
+                StringBuilder builder = new StringBuilder();
+                builder.append("AWSIAMDatabase\n");
+                builder.append(context.getIndentationString()).append(getTabString(baseIndentation)).append("{\n");
+                builder.append(context.getIndentationString()).append(getTabString(baseIndentation + 1)).append("databaseUsername: ").append(convertString(iamStrategy.databaseUsername, true)).append(";\n");
+                if (iamStrategy.awsCredentials != null)
+                {
+                    builder.append(context.getIndentationString()).append(getTabString(baseIndentation + 1)).append("awsCredentials: ");
+                    builder.append(composeAwsCredentials(iamStrategy.awsCredentials, context, baseIndentation + 1));
+                    builder.append(";\n");
+                }
+                builder.append(context.getIndentationString()).append(getTabString(baseIndentation)).append("}");
+                return builder.toString();
+            }
+            return null;
+        });
+    }
+
+    private String composeAwsCredentials(AWSCredentials credentials, PureGrammarComposerContext context, int indentation)
+    {
+        if (credentials instanceof AWSDefaultCredentials)
+        {
+            return "Default {}";
+        }
+        if (credentials instanceof AWSStaticCredentials)
+        {
+            AWSStaticCredentials staticCreds = (AWSStaticCredentials) credentials;
+            StringBuilder builder = new StringBuilder();
+            builder.append("Static\n");
+            builder.append(context.getIndentationString()).append(getTabString(indentation + 1)).append("{\n");
+            builder.append(context.getIndentationString()).append(getTabString(indentation + 2)).append("accessKeyId: ").append(composeSecret(staticCreds.accessKeyId)).append(";\n");
+            builder.append(context.getIndentationString()).append(getTabString(indentation + 2)).append("secretAccessKey: ").append(composeSecret(staticCreds.secretAccessKey)).append(";\n");
+            builder.append(context.getIndentationString()).append(getTabString(indentation + 1)).append("}");
+            return builder.toString();
+        }
+        if (credentials instanceof AWSSTSAssumeRoleCredentials)
+        {
+            AWSSTSAssumeRoleCredentials stsCreds = (AWSSTSAssumeRoleCredentials) credentials;
+            StringBuilder builder = new StringBuilder();
+            builder.append("STSAssumeRole\n");
+            builder.append(context.getIndentationString()).append(getTabString(indentation + 1)).append("{\n");
+            builder.append(context.getIndentationString()).append(getTabString(indentation + 2)).append("roleArn: ").append(convertString(stsCreds.roleArn, true)).append(";\n");
+            if (stsCreds.awsCredentials != null)
+            {
+                builder.append(context.getIndentationString()).append(getTabString(indentation + 2)).append("awsCredentials: ");
+                builder.append(composeAwsCredentials(stsCreds.awsCredentials, context, indentation + 2));
+                builder.append(";\n");
+            }
+            builder.append(context.getIndentationString()).append(getTabString(indentation + 1)).append("}");
+            return builder.toString();
+        }
+        throw new RuntimeException("Unsupported AWS credentials type: " + credentials.getClass().getSimpleName());
+    }
+
+    private String composeSecret(CredentialVaultSecret secret)
+    {
+        if (secret instanceof PropertiesFileSecret)
+        {
+            return convertString(((PropertiesFileSecret) secret).propertyName, true);
+        }
+        throw new RuntimeException("Unsupported secret type: " + secret.getClass().getSimpleName());
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/resources/META-INF/services/org.finos.legend.engine.language.pure.compiler.toPureGraph.extension.CompilerExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.compiler.toPureGraph.AuroraPostgresCompilerExtension

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.from.IRelationalGrammarParserExtension
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.from.IRelationalGrammarParserExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.grammar.from.AuroraPostgresGrammarParserExtension

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-grammar/src/main/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.to.extension.PureGrammarComposerExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.grammar.to.AuroraPostgresGrammarComposerExtension

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2025 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-xt-relationalStore-aurora-postgres</artifactId>
+        <version>4.118.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>legend-engine-xt-relationalStore-aurora-postgres-protocol</artifactId>
+    <packaging>jar</packaging>
+    <name>Legend Engine - XT - Relational Store - Aurora PostgreSQL - Protocol</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol-pure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-authentication-protocol</artifactId>
+        </dependency>
+
+        <!-- ECLIPSE COLLECTIONS -->
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+        <!-- ECLIPSE COLLECTIONS -->
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/AuroraPostgresProtocolExtension.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/AuroraPostgresProtocolExtension.java
@@ -1,0 +1,51 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure.v1;
+
+import org.eclipse.collections.api.block.function.Function0;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.finos.legend.engine.protocol.pure.v1.extension.ProtocolSubTypeInfo;
+import org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AWSIAMDatabaseAuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AuthenticationStrategy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.AuroraPostgresDatasourceSpecification;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification.DatasourceSpecification;
+
+import java.util.List;
+
+public class AuroraPostgresProtocolExtension implements PureProtocolExtension
+{
+    @Override
+    public MutableList<String> group()
+    {
+        return Lists.mutable.with("Store", "Relational", "AuroraPostgres");
+    }
+
+    @Override
+    public List<Function0<List<ProtocolSubTypeInfo<?>>>> getExtraProtocolSubTypeInfoCollectors()
+    {
+        return Lists.fixedSize.with(() -> Lists.fixedSize.with(
+                // DatasourceSpecification
+                ProtocolSubTypeInfo.newBuilder(DatasourceSpecification.class)
+                        .withSubtype(AuroraPostgresDatasourceSpecification.class, "auroraPostgres")
+                        .build(),
+                // AuthenticationStrategy
+                ProtocolSubTypeInfo.newBuilder(AuthenticationStrategy.class)
+                        .withSubtype(AWSIAMDatabaseAuthenticationStrategy.class, "awsIAMDatabase")
+                        .build()
+        ));
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/authentication/AWSIAMDatabaseAuthenticationStrategy.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/authentication/AWSIAMDatabaseAuthenticationStrategy.java
@@ -1,0 +1,56 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication;
+
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.authentication.vault.aws.AWSCredentials;
+
+/**
+ * Authentication strategy for AWS IAM Database Authentication.
+ * 
+ * This strategy uses AWS IAM credentials to generate short-lived authentication
+ * tokens that are used as passwords when connecting to Aurora PostgreSQL databases.
+ * 
+ * Prerequisites:
+ * - The Aurora cluster must have IAM database authentication enabled
+ * - A database user must be created and granted the rds_iam role
+ * - The IAM principal must have the rds-db:connect permission
+ */
+public class AWSIAMDatabaseAuthenticationStrategy extends AuthenticationStrategy
+{
+    /**
+     * The database username that has been configured for IAM authentication.
+     * This user must exist in the database and have the rds_iam role granted.
+     * 
+     * In PostgreSQL, this is created with:
+     * CREATE USER iam_user WITH LOGIN;
+     * GRANT rds_iam TO iam_user;
+     */
+    public String databaseUsername;
+
+    /**
+     * AWS credentials configuration for obtaining IAM authentication tokens.
+     * Can be one of:
+     * - AWSDefaultCredentials: Use default credential chain (environment, instance profile, etc.)
+     * - AWSStaticCredentials: Use explicit access key and secret
+     * - AWSSTSAssumeRoleCredentials: Assume an IAM role
+     */
+    public AWSCredentials awsCredentials;
+
+    @Override
+    public <T> T accept(AuthenticationStrategyVisitor<T> authenticationStrategyVisitor)
+    {
+        return authenticationStrategyVisitor.visit(this);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/specification/AuroraPostgresDatasourceSpecification.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/relational/connection/specification/AuroraPostgresDatasourceSpecification.java
@@ -1,0 +1,58 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.specification;
+
+/**
+ * Datasource specification for AWS Aurora PostgreSQL databases.
+ * Aurora PostgreSQL is wire-compatible with PostgreSQL but requires
+ * Aurora-specific connection parameters for IAM authentication.
+ */
+public class AuroraPostgresDatasourceSpecification extends DatasourceSpecification
+{
+    /**
+     * The Aurora cluster endpoint hostname.
+     * Example: my-cluster.cluster-xxxxx.us-east-1.rds.amazonaws.com
+     */
+    public String host;
+
+    /**
+     * The database port (default: 5432 for PostgreSQL).
+     */
+    public int port;
+
+    /**
+     * The name of the database to connect to.
+     */
+    public String databaseName;
+
+    /**
+     * The AWS region where the Aurora cluster is located.
+     * Required for IAM authentication token generation.
+     * Example: us-east-1
+     */
+    public String region;
+
+    /**
+     * Optional Aurora cluster identifier.
+     * Useful for reference and logging.
+     */
+    public String clusterIdentifier;
+
+    @Override
+    public <T> T accept(DatasourceSpecificationVisitor<T> datasourceSpecificationVisitor)
+    {
+        return datasourceSpecificationVisitor.visit(this);
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/src/main/resources/META-INF/services/org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-protocol/src/main/resources/META-INF/services/org.finos.legend.engine.protocol.pure.v1.extension.PureProtocolExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.protocol.pure.v1.AuroraPostgresProtocolExtension

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2025 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-xt-relationalStore-aurora-postgres</artifactId>
+        <version>4.118.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>legend-engine-xt-relationalStore-aurora-postgres-pure</artifactId>
+    <packaging>jar</packaging>
+    <name>Legend Engine - XT - Relational Store - Aurora PostgreSQL - Pure</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-pure</artifactId>
+        </dependency>
+
+        <!-- ECLIPSE COLLECTIONS -->
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+        <!-- ECLIPSE COLLECTIONS -->
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/java/org/finos/legend/pure/code/core/CoreRelationalAuroraPostgresCodeRepositoryProvider.java
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/java/org/finos/legend/pure/code/core/CoreRelationalAuroraPostgresCodeRepositoryProvider.java
@@ -1,0 +1,28 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.pure.code.core;
+
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepository;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProvider;
+import org.finos.legend.pure.m3.serialization.filesystem.repository.GenericCodeRepository;
+
+public class CoreRelationalAuroraPostgresCodeRepositoryProvider implements CodeRepositoryProvider
+{
+    @Override
+    public CodeRepository repository()
+    {
+        return GenericCodeRepository.build("core_relational_aurora_postgres.definition.json");
+    }
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/resources/META-INF/services/org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProvider
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/resources/META-INF/services/org.finos.legend.pure.m3.serialization.filesystem.repository.CodeRepositoryProvider
@@ -1,0 +1,1 @@
+org.finos.legend.pure.code.core.CoreRelationalAuroraPostgresCodeRepositoryProvider

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/resources/core_relational_aurora_postgres.definition.json
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/resources/core_relational_aurora_postgres.definition.json
@@ -1,0 +1,7 @@
+{
+  "name": "core_relational_aurora_postgres",
+  "pattern": "(meta::relational::functions|meta::pure::legend::connections|meta::protocols::pure::vX_X_X::transformation::fromPureGraph::connection::auroraPostgres)",
+  "dependencies": [
+    "core_relational"
+  ]
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/resources/core_relational_aurora_postgres/relational/connection/metamodel.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/resources/core_relational_aurora_postgres/relational/connection/metamodel.pure
@@ -1,0 +1,43 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Datasource specification for AWS Aurora PostgreSQL databases.
+ * 
+ * Aurora PostgreSQL is wire-compatible with PostgreSQL but requires
+ * Aurora-specific connection parameters for IAM authentication.
+ */
+Class {doc.doc = 'Specification for AWS Aurora PostgreSQL database'}
+meta::pure::legend::connections::legend::specification::AuroraPostgresDatasourceSpecification 
+    extends meta::pure::alloy::connections::alloy::specification::DatasourceSpecification
+{
+    <<equality.Key>> {doc.doc = 'Aurora cluster endpoint hostname'} host: String[1];
+    <<equality.Key>> {doc.doc = 'Database port (default 5432)'} port: Integer[1];
+    <<equality.Key>> {doc.doc = 'Database name'} databaseName: String[1];
+    <<equality.Key>> {doc.doc = 'AWS region for IAM authentication'} region: String[1];
+    <<equality.Key>> {doc.doc = 'Optional Aurora cluster identifier'} clusterIdentifier: String[0..1];
+}
+
+/**
+ * Authentication strategy for AWS IAM Database Authentication.
+ * 
+ * This strategy uses AWS IAM credentials to generate short-lived authentication
+ * tokens that are used as passwords when connecting to Aurora PostgreSQL databases.
+ */
+Class {doc.doc = 'AWS IAM Database Authentication Strategy'}
+meta::pure::legend::connections::legend::authentication::AWSIAMDatabaseAuthenticationStrategy 
+    extends meta::pure::alloy::connections::alloy::authentication::AuthenticationStrategy
+{
+    <<equality.Key>> {doc.doc = 'Database username configured for IAM authentication'} databaseUsername: String[1];
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/resources/core_relational_aurora_postgres/relational/protocols/pure/vX_X_X/extension/extension_aurora_postgres.pure
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/legend-engine-xt-relationalStore-aurora-postgres-pure/src/main/resources/core_relational_aurora_postgres/relational/protocols/pure/vX_X_X/extension/extension_aurora_postgres.pure
@@ -1,0 +1,79 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+###Pure
+import meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::legend::specification::*;
+import meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::legend::authentication::*;
+
+Class meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::legend::specification::AuroraPostgresDatasourceSpecification 
+    extends meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::alloy::specification::DatasourceSpecification
+{
+    host: String[1];
+    port: Integer[1];
+    databaseName: String[1];
+    region: String[1];
+    clusterIdentifier: String[0..1];
+}
+
+Class meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::legend::authentication::AWSIAMDatabaseAuthenticationStrategy 
+    extends meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::alloy::authentication::AuthenticationStrategy
+{
+    databaseUsername: String[1];
+}
+
+function <<meta::protocols::pure::vX_X_X::extension::RelationalModule.SerializerExtension>>
+meta::protocols::pure::vX_X_X::transformation::fromPureGraph::connection::auroraPostgresSerializerExtension(): meta::protocols::pure::vX_X_X::extension::RelationalModuleSerializerExtension[1]
+{
+    ^meta::protocols::pure::vX_X_X::extension::RelationalModuleSerializerExtension(
+        module = 'aurora_postgres',
+        transfers_connection_transformDatasourceSpecification = [
+            a:meta::pure::legend::connections::legend::specification::AuroraPostgresDatasourceSpecification[1] |
+                ^meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::legend::specification::AuroraPostgresDatasourceSpecification(
+                    _type = 'auroraPostgres',
+                    host = $a.host,
+                    port = $a.port,
+                    databaseName = $a.databaseName,
+                    region = $a.region,
+                    clusterIdentifier = $a.clusterIdentifier
+                )
+        ],
+        transfers_connection_transformAuthenticationStrategy = [
+            a:meta::pure::legend::connections::legend::authentication::AWSIAMDatabaseAuthenticationStrategy[1] |
+                ^meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::legend::authentication::AWSIAMDatabaseAuthenticationStrategy(
+                    _type = 'awsIAMDatabase',
+                    databaseUsername = $a.databaseUsername
+                )
+        ],
+        reverse_transfers_typeLookups = [
+            pair('auroraPostgres', 'AuroraPostgresDatasourceSpecification'),
+            pair('awsIAMDatabase', 'AWSIAMDatabaseAuthenticationStrategy')
+        ],
+        reverse_transfers_connection_transformDatasourceSpecification = [
+            a:meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::legend::specification::AuroraPostgresDatasourceSpecification[1] |
+                ^meta::pure::legend::connections::legend::specification::AuroraPostgresDatasourceSpecification(
+                    host = $a.host,
+                    port = $a.port,
+                    databaseName = $a.databaseName,
+                    region = $a.region,
+                    clusterIdentifier = $a.clusterIdentifier
+                )
+        ],
+        reverse_transfers_connection_transformAuthenticationStrategy = [
+            a:meta::protocols::pure::vX_X_X::metamodel::store::relational::connection::legend::authentication::AWSIAMDatabaseAuthenticationStrategy[1] |
+                ^meta::pure::legend::connections::legend::authentication::AWSIAMDatabaseAuthenticationStrategy(
+                    databaseUsername = $a.databaseUsername
+                )
+        ]
+    )
+}

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/legend-engine-xt-relationalStore-aurora-postgres/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2025 Goldman Sachs
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.finos.legend.engine</groupId>
+        <artifactId>legend-engine-xt-relationalStore-dbExtension</artifactId>
+        <version>4.118.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>legend-engine-xt-relationalStore-aurora-postgres</artifactId>
+    <packaging>pom</packaging>
+    <name>Legend Engine - XT - Relational Store - DB Extension - Aurora PostgreSQL</name>
+
+    <modules>
+        <module>legend-engine-xt-relationalStore-aurora-postgres-protocol</module>
+        <module>legend-engine-xt-relationalStore-aurora-postgres-execution</module>
+        <module>legend-engine-xt-relationalStore-aurora-postgres-grammar</module>
+        <module>legend-engine-xt-relationalStore-aurora-postgres-pure</module>
+    </modules>
+
+</project>

--- a/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/pom.xml
+++ b/legend-engine-xts-relationalStore/legend-engine-xt-relationalStore-dbExtension/pom.xml
@@ -44,6 +44,7 @@
         <module>legend-engine-xt-relationalStore-databricks</module>
         <module>legend-engine-xt-relationalStore-sparksql</module>
         <module>legend-engine-xt-relationalStore-h2</module>
+        <module>legend-engine-xt-relationalStore-aurora-postgres</module>
 
 <!--        <module>legend-engine-xt-relationalStore-test-reports</module>-->
 <!--        <module>legend-engine-xt-relationalStore-test-http-server</module>-->


### PR DESCRIPTION
## Summary

This PR adds a new database extension module for connecting to AWS Aurora PostgreSQL databases using IAM Database Authentication instead of username/password.

### Key Features

- **AuroraPostgresDatasourceSpecification**: Connection parameters for Aurora clusters including host, port, database name, AWS region, and cluster identifier
- **AWSIAMDatabaseAuthenticationStrategy**: Authentication using AWS IAM credentials to generate short-lived authentication tokens
- Support for multiple AWS credential types:
  - AWS Default credentials (environment, instance profile, etc.)
  - Static credentials (access key/secret from vault)
  - STS Assume Role

### Module Structure

The implementation follows the existing database extension pattern with 4 sub-modules:
- **protocol**: DatasourceSpecification and AuthenticationStrategy protocol classes
- **execution**: Authentication flows, connection management, JDBC driver wrapper
- **grammar**: ANTLR lexer/parser for DSL support
- **pure**: Metamodel definitions and serialization extensions

### Usage Example

```legend
RelationalDatabaseConnection my::AuroraConnection
{
    store: my::Store;
    type: Postgres;
    specification: AuroraPostgres
    {
        host: 'my-cluster.cluster-xxxxx.us-east-1.rds.amazonaws.com';
        port: 5432;
        name: 'mydb';
        region: 'us-east-1';
    };
    auth: AWSIAMDatabase
    {
        databaseUsername: 'iam_db_user';
        awsCredentials: Default {};
    };
}
```

## Test Plan

- [ ] Build the module with `mvn clean install`
- [ ] Verify ANTLR grammar generation
- [ ] Test connection to Aurora PostgreSQL cluster with IAM authentication enabled
- [ ] Verify IAM token generation works with different credential types (Default, Static, STS)

## Prerequisites for Aurora IAM Auth

1. Enable IAM database authentication on your Aurora cluster
2. Create a database user with IAM role:
   ```sql
   CREATE USER iam_db_user WITH LOGIN;
   GRANT rds_iam TO iam_db_user;
   ```
3. Grant the IAM principal `rds-db:connect` permission

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds first-class Aurora PostgreSQL connectivity using AWS IAM tokens and wires it through protocol, grammar, pure, and execution layers.
> 
> - New module `legend-engine-xt-relationalStore-aurora-postgres` with submodules: `protocol`, `execution`, `grammar`, `pure`; parent `dbExtension` POM updated to include it
> - Protocol: `AuroraPostgresDatasourceSpecification` (host/port/name/region/clusterIdentifier) and `AWSIAMDatabaseAuthenticationStrategy` (supports Default/Static/STS credentials); protocol subtype registrations
> - Grammar: ANTLR lexer/parser, parser/composer extensions for `AuroraPostgres` datasource and `AWSIAMDatabase` auth
> - Pure: metamodel classes and serializer extension to/from protocol types; new Pure code repository registration
> - Execution: IAM flow and connection plumbing
>   - `AuroraPostgresWithIAMAuthFlow` generates RDS auth tokens; credential resolution for Default/Static/STS (vault lookups)
>   - `AuroraPostgresConnectionExtension` provides keys/transformers; `AWSIAMDatabaseAuthenticationStrategyKey`
>   - Aurora-specific manager/driver/commands and datasource spec/key (`AuroraPostgresManager`, `AuroraPostgresDriver`, `AuroraPostgresCommands`, `AuroraPostgresDataSourceSpecification`, `AuroraPostgresDataSourceSpecificationKey`)
>   - Service provider registrations for flow and connection extensions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3037bb6bc85dceb9aec8547c454a781982fde5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->